### PR TITLE
feat: add automatic ChatGPT model switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ Change it with `VNC_PASSWORD` in `docker-compose.yml`.
 
 ### OpenAI-Compatible Endpoints
 
+`catgpt-browser` is the default browser alias. If you send an explicit paid-plan
+model id like `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`,
+`gpt-5.4-nano`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5`, `gpt-5.3`, `o3`, `o4-mini`,
+`gpt-4.5`, `gpt-4.1`, `gpt-4.1-mini`, or `gpt-4o`, CatGPT will try to switch
+the ChatGPT web UI to that model before sending the prompt. If you want
+`catgpt-browser` itself to auto-switch, set `CHATGPT_DEFAULT_MODEL` to one of
+the configured ids.
+
 Base URL: `http://localhost:8000/v1` — **Model ID:** `catgpt-browser`
 
 | Method | Path                     | Description                                                                     |
@@ -202,7 +210,7 @@ Base URL: `http://localhost:8000/v1` — **Model ID:** `catgpt-browser`
 | `POST` | `/v1/chat/completions/async` | Submit async chat job (poll with job ID). Structured output supported.      |
 | `GET`  | `/v1/chat/completions/async/{job_id}` | Get async job status/result (`queued/running/completed/failed`). |
 | `POST` | `/v1/images/generations` | Generate images via DALL-E                                                      |
-| `GET`  | `/v1/models`             | List available models (returns `catgpt-browser`)                                |
+| `GET`  | `/v1/models`             | List available browser-backed chat model ids (`catgpt-browser` + configured models) |
 | `POST` | `/{app_name}/v1/chat/completions` | App-scoped chat completions (derives app from URL path)             |
 | `POST` | `/{app_name}/v1/chat/completions/async` | App-scoped async chat submit                                      |
 | `GET`  | `/{app_name}/v1/chat/completions/async/{job_id}` | App-scoped async status/result                           |
@@ -591,6 +599,9 @@ All settings are loaded from environment variables (`.env` file or `docker-compo
 | `HEADLESS`           | `false`               | Run browser headless (not recommended — easily detected) |
 | `SLOW_MO`            | `0`                   | Playwright slow-motion delay (ms) for debugging          |
 | `CHATGPT_URL`        | `https://chatgpt.com` | Target ChatGPT URL                                       |
+| `CHATGPT_DEFAULT_MODEL` | ``                  | Optional model id to auto-apply when requests use `catgpt-browser` |
+| `CHATGPT_MODEL_ALIASES` | `gpt-5.3=GPT-5.3,...` | Comma-separated `public_id=UI label` map for browser model switching |
+| `CHATGPT_MODEL_SWITCH_TIMEOUT` | `10000`     | Max wait time (ms) to confirm the ChatGPT UI switched models |
 | `RESPONSE_TIMEOUT`   | `120000`              | Max wait for ChatGPT response (ms)                       |
 | `SELECTOR_TIMEOUT`   | `5000`                | Timeout per selector probe (ms)                          |
 | `TYPE_DELAY_MIN`     | `50`                  | Min delay between keystrokes (ms)                        |

--- a/src/api/openai_routes.py
+++ b/src/api/openai_routes.py
@@ -41,6 +41,11 @@ from src.api.openai_schemas import (
     UsageInfo,
 )
 from src.chatgpt.client import ChatGPTClient
+from src.chatgpt.model_registry import (
+    PUBLIC_BROWSER_MODEL_ID,
+    is_supported_chat_model,
+    list_public_chat_models,
+)
 from src.config import Config
 from src.log import setup_logging
 
@@ -65,7 +70,7 @@ _thread_last_user_text: dict[str, tuple[float, str]] = {}
 _app_thread_lock = asyncio.Lock()
 _app_threads: dict[str, tuple[float, str]] = {}
 
-MODEL_ID = "catgpt-browser"
+MODEL_ID = PUBLIC_BROWSER_MODEL_ID
 _CACHE_TTL_SECONDS = 600
 _CACHE_MAX_ENTRIES = 256
 _CONTRACT_TTL_SECONDS = max(60, Config.API_THREAD_CONTRACT_TTL_SECONDS)
@@ -1229,6 +1234,13 @@ def _validate_chat_request(request: ChatCompletionRequest) -> None:
     if not request.messages:
         raise HTTPException(status_code=400, detail="messages array cannot be empty")
 
+    if not is_supported_chat_model(request.model):
+        supported = ", ".join(list_public_chat_models())
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported model '{request.model}'. Supported models: {supported}",
+        )
+
 
 def _resolve_app_key(
     request: ChatCompletionRequest,
@@ -1246,11 +1258,9 @@ def _resolve_app_key(
 
 @openai_router.get("/v1/models", response_model=ModelListResponse)
 async def list_models() -> ModelListResponse:
-    """List available models - returns our single browser-backed model."""
+    """List available browser-backed chat model ids."""
     return ModelListResponse(
-        data=[
-            ModelObject(id=MODEL_ID, owned_by="catgpt"),
-        ]
+        data=[ModelObject(id=model_id, owned_by="catgpt") for model_id in list_public_chat_models()]
     )
 
 
@@ -1601,6 +1611,7 @@ async def _execute_chat_completion(
                 prompt,
                 image_paths=image_paths or None,
                 file_paths=file_paths or None,
+                model=request.model,
             )
         except Exception as e:
             log.error(f"ChatGPT error: {e}", exc_info=True)
@@ -1641,6 +1652,7 @@ async def _execute_chat_completion(
                     full_prompt,
                     image_paths=image_paths or None,
                     file_paths=file_paths or None,
+                    model=request.model,
                 )
                 response_text = full_retry.message
                 elapsed_ms = int((time.time() - start_time) * 1000)
@@ -1688,6 +1700,7 @@ async def _execute_chat_completion(
                         retry_prompt,
                         image_paths=image_paths or None,
                         file_paths=file_paths or None,
+                        model=request.model,
                     )
                     retry_text = retry_result.message
                     retry_text = _normalize_structured_content(retry_text, request.response_format)

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -25,6 +25,7 @@ from src.api.schemas import (
 )
 from src.browser.manager import BrowserManager
 from src.chatgpt.client import ChatGPTClient
+from src.chatgpt.model_registry import is_supported_chat_model, list_public_chat_models
 from src.log import setup_logging
 
 log = setup_logging("api_routes")
@@ -72,6 +73,20 @@ def _build_response(result) -> ChatResponse:
     )
 
 
+def _validate_model(model: str | None) -> None:
+    """Reject unsupported browser model ids early for the native REST routes."""
+    if not model:
+        return
+    if is_supported_chat_model(model):
+        return
+
+    supported = ", ".join(list_public_chat_models())
+    raise HTTPException(
+        status_code=400,
+        detail=f"Unsupported model '{model}'. Supported models: {supported}",
+    )
+
+
 # ── Chat ────────────────────────────────────────────────────────
 
 
@@ -83,7 +98,8 @@ async def chat(req: ChatRequest) -> ChatResponse:
 
     async with _lock:
         try:
-            result = await client.send_message(req.message)
+            _validate_model(req.model)
+            result = await client.send_message(req.message, model=req.model)
             return _build_response(result)
         except Exception as e:
             log.error(f"Chat error: {e}", exc_info=True)
@@ -98,12 +114,13 @@ async def chat_in_thread(thread_id: str, req: ChatRequest) -> ChatResponse:
 
     async with _lock:
         try:
+            _validate_model(req.model)
             # Navigate to the thread if not already there
             current_tid = client._extract_thread_id()
             if current_tid != thread_id:
                 await client.navigate_to_thread(thread_id)
 
-            result = await client.send_message(req.message)
+            result = await client.send_message(req.message, model=req.model)
             return _build_response(result)
         except Exception as e:
             log.error(f"Thread chat error: {e}", exc_info=True)
@@ -118,8 +135,9 @@ async def new_thread(req: ChatRequest) -> ChatResponse:
 
     async with _lock:
         try:
+            _validate_model(req.model)
             await client.new_chat()
-            result = await client.send_message(req.message)
+            result = await client.send_message(req.message, model=req.model)
             return _build_response(result)
         except Exception as e:
             log.error(f"New thread error: {e}", exc_info=True)

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 class ChatRequest(BaseModel):
     """Request body for sending a message."""
     message: str = Field(..., min_length=1, description="The message to send to ChatGPT")
+    model: str | None = Field(None, description="Optional ChatGPT model id / label to switch to before sending")
 
 
 class ImageInfoResponse(BaseModel):

--- a/src/chatgpt/client.py
+++ b/src/chatgpt/client.py
@@ -13,6 +13,11 @@ import time
 
 from patchright.async_api import Page
 
+from src.chatgpt.model_registry import (
+    list_switchable_models,
+    normalize_model_token,
+    resolve_requested_model,
+)
 from src.config import Config
 from src.selectors import Selectors
 from src.browser.human import human_type, human_click, thinking_pause, random_delay
@@ -37,6 +42,7 @@ class ChatGPTClient:
 
     def __init__(self, page: Page) -> None:
         self._page = page
+        self._last_model_label = ""
 
     @property
     def page(self) -> Page:
@@ -44,7 +50,13 @@ class ChatGPTClient:
 
     # ── Core: Send & Receive ────────────────────────────────────
 
-    async def send_message(self, text: str, image_paths: list[str] | None = None, file_paths: list[str] | None = None) -> ChatResponse:
+    async def send_message(
+        self,
+        text: str,
+        image_paths: list[str] | None = None,
+        file_paths: list[str] | None = None,
+        model: str | None = None,
+    ) -> ChatResponse:
         """
         Send a message to ChatGPT and wait for the complete response.
 
@@ -72,10 +84,14 @@ class ChatGPTClient:
         pre_count = await count_assistant_messages(self._page)
         log.debug(f"Assistant messages before send: {pre_count}")
 
-        # 1. Brief pause (human would take a moment to start typing)
+        # 1. Switch model if requested before interacting with the composer
+        if model:
+            await self.ensure_model(model)
+
+        # 2. Brief pause (human would take a moment to start typing)
         await random_delay(500, 1200)
 
-        # 1.5. Upload files/images if provided
+        # 2.5. Upload files/images if provided
         if all_attachments:
             await self._upload_files(all_attachments)
 
@@ -144,6 +160,51 @@ class ChatGPTClient:
             images=images,
             has_images=has_images,
         )
+
+    async def ensure_model(self, requested_model: str) -> None:
+        """Switch ChatGPT's model picker to the requested model when possible."""
+        target = resolve_requested_model(requested_model)
+        if target is None:
+            log.debug(f"No explicit browser model switch needed for request model={requested_model!r}")
+            return
+
+        current_label = await self._detect_current_model_label()
+        if current_label and normalize_model_token(current_label) == normalize_model_token(target.ui_label):
+            self._last_model_label = target.ui_label
+            log.debug(f"ChatGPT model already selected: {target.ui_label}")
+            return
+
+        log.info(
+            "Switching ChatGPT model: request=%s target=%s current=%s",
+            requested_model,
+            target.ui_label,
+            current_label or self._last_model_label or "unknown",
+        )
+
+        opened = await self._open_model_picker(target.ui_label, current_label=current_label)
+        if not opened:
+            raise RuntimeError(f"Could not open ChatGPT model picker for '{target.ui_label}'")
+
+        await asyncio.sleep(0.4)
+
+        switched = await self._click_model_option(target.ui_label)
+        if not switched:
+            more_models_opened = await self._click_menu_text("More models")
+            if more_models_opened:
+                await asyncio.sleep(0.3)
+                switched = await self._click_model_option(target.ui_label)
+
+        if not switched:
+            raise RuntimeError(f"Could not find ChatGPT model option '{target.ui_label}' in the model picker")
+
+        confirmed = await self._wait_for_model_label(target.ui_label)
+        if not confirmed:
+            current_after = await self._detect_current_model_label()
+            if normalize_model_token(current_after) != normalize_model_token(target.ui_label):
+                raise RuntimeError(f"Model switch to '{target.ui_label}' could not be confirmed")
+
+        self._last_model_label = target.ui_label
+        log.info(f"Model switched to {target.ui_label}")
 
     # ── Navigation ──────────────────────────────────────────────
 
@@ -271,6 +332,248 @@ class ChatGPTClient:
             await human_click(self._page, selector)
             log.debug("Send button clicked")
             return True
+        return False
+
+    async def _detect_current_model_label(self) -> str:
+        """Best-effort detection of the currently selected ChatGPT model label."""
+        known_labels = [option.ui_label for option in list_switchable_models()]
+        if self._last_model_label and self._last_model_label not in known_labels:
+            known_labels.append(self._last_model_label)
+        if not known_labels:
+            return ""
+
+        label = await self._page.evaluate(
+            r"""
+            (knownLabels) => {
+                const normalize = (value) =>
+                    (value || "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+                const isVisible = (el) => {
+                    if (!el) return false;
+                    const rect = el.getBoundingClientRect();
+                    const style = window.getComputedStyle(el);
+                    return rect.width > 0 &&
+                        rect.height > 0 &&
+                        style.visibility !== "hidden" &&
+                        style.display !== "none";
+                };
+                const wanted = (knownLabels || []).map((label) => ({
+                    label,
+                    normalized: normalize(label),
+                })).filter((item) => item.normalized);
+                const clickable = Array.from(document.querySelectorAll("button,[role='button'],[role='tab']"));
+                const matches = [];
+                for (const el of clickable) {
+                    if (!isVisible(el)) continue;
+                    const rect = el.getBoundingClientRect();
+                    const primaryText = ((el.innerText || el.textContent || "")
+                        .split(/\n+/)
+                        .map((part) => part.trim())
+                        .filter(Boolean)[0] || "").trim();
+                    const rawText = [
+                        primaryText,
+                        el.innerText || "",
+                        el.textContent || "",
+                        el.getAttribute("aria-label") || "",
+                        el.getAttribute("title") || "",
+                    ].join(" ").trim();
+                    const normalizedText = normalize(rawText);
+                    const normalizedPrimary = normalize(primaryText);
+                    if (!normalizedText) continue;
+                    for (const wantedLabel of wanted) {
+                        if (!normalizedText.includes(wantedLabel.normalized)) continue;
+                        let score = 0;
+                        if (normalizedPrimary === wantedLabel.normalized) score += 70;
+                        else if (normalizedText === wantedLabel.normalized) score += 50;
+                        else if (normalizedPrimary.startsWith(wantedLabel.normalized)) score += 35;
+                        else if (normalizedText.startsWith(wantedLabel.normalized)) score += 25;
+                        else score += 10;
+                        score += Math.min(10, wantedLabel.normalized.length);
+                        if (rect.top < 260) score += 20;
+                        if (rect.left < 500) score += 10;
+                        matches.push({
+                            label: wantedLabel.label,
+                            score,
+                            top: rect.top,
+                            left: rect.left,
+                        });
+                    }
+                }
+                matches.sort((a, b) => b.score - a.score || a.top - b.top || a.left - b.left);
+                return matches.length ? matches[0].label : "";
+            }
+            """,
+            known_labels,
+        )
+        return (label or "").strip()
+
+    async def _open_model_picker(self, target_label: str, current_label: str = "") -> bool:
+        """Open ChatGPT's model picker using the visible current-model button."""
+        for selector in Selectors.MODEL_PICKER_BUTTON:
+            try:
+                el = await self._page.wait_for_selector(selector, timeout=1000, state="visible")
+                if el:
+                    await human_click(self._page, selector)
+                    return True
+            except Exception:
+                continue
+
+        hints = [current_label, self._last_model_label, target_label, "model", "GPT", "o3", "o4"]
+        if await self._click_top_button_by_text(hints):
+            return True
+
+        return False
+
+    async def _click_top_button_by_text(self, hints: list[str]) -> bool:
+        """Click a visible top-of-page button whose label best matches the hints."""
+        filtered_hints = [hint for hint in hints if (hint or "").strip()]
+        if not filtered_hints:
+            return False
+
+        clicked = await self._page.evaluate(
+            r"""
+            (hints) => {
+                const normalize = (value) =>
+                    (value || "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+                const wanted = (hints || []).map(normalize).filter(Boolean);
+                const isVisible = (el) => {
+                    if (!el) return false;
+                    const rect = el.getBoundingClientRect();
+                    const style = window.getComputedStyle(el);
+                    return rect.width > 0 &&
+                        rect.height > 0 &&
+                        style.visibility !== "hidden" &&
+                        style.display !== "none";
+                };
+                const clickable = Array.from(document.querySelectorAll("button,[role='button'],[role='tab']"));
+                const matches = [];
+                for (const el of clickable) {
+                    if (!isVisible(el)) continue;
+                    const rect = el.getBoundingClientRect();
+                    if (rect.top > 320) continue;
+                    const primaryText = ((el.innerText || el.textContent || "")
+                        .split(/\n+/)
+                        .map((part) => part.trim())
+                        .filter(Boolean)[0] || "").trim();
+                    const text = [
+                        primaryText,
+                        el.innerText || "",
+                        el.textContent || "",
+                        el.getAttribute("aria-label") || "",
+                        el.getAttribute("title") || "",
+                    ].join(" ").trim();
+                    const normalizedText = normalize(text);
+                    const normalizedPrimary = normalize(primaryText);
+                    if (!normalizedText) continue;
+                    let score = 0;
+                    for (const hint of wanted) {
+                        if (!normalizedText.includes(hint)) continue;
+                        score = Math.max(
+                            score,
+                            normalizedPrimary === hint
+                                ? 70
+                                : normalizedText === hint
+                                  ? 60
+                                  : normalizedPrimary.startsWith(hint)
+                                    ? 45
+                                    : normalizedText.startsWith(hint)
+                                      ? 40
+                                      : 20,
+                        );
+                    }
+                    if (!score) continue;
+                    if (rect.left < 500) score += 10;
+                    matches.push({ el, score, top: rect.top, left: rect.left });
+                }
+                matches.sort((a, b) => b.score - a.score || a.top - b.top || a.left - b.left);
+                const best = matches[0];
+                if (!best) return false;
+                best.el.click();
+                return true;
+            }
+            """,
+            filtered_hints,
+        )
+        return bool(clicked)
+
+    async def _click_model_option(self, target_label: str) -> bool:
+        """Click a visible model option in an open picker/menu by its label."""
+        return await self._click_menu_text(target_label)
+
+    async def _click_menu_text(self, target_text: str) -> bool:
+        """Click a visible menu-style element whose text matches the target."""
+        clicked = await self._page.evaluate(
+            r"""
+            (targetText) => {
+                const normalize = (value) =>
+                    (value || "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+                const target = normalize(targetText);
+                if (!target) return false;
+                const isVisible = (el) => {
+                    if (!el) return false;
+                    const rect = el.getBoundingClientRect();
+                    const style = window.getComputedStyle(el);
+                    return rect.width > 0 &&
+                        rect.height > 0 &&
+                        style.visibility !== "hidden" &&
+                        style.display !== "none";
+                };
+                const selectors = [
+                    "[role='menuitemradio']",
+                    "[role='menuitem']",
+                    "[role='option']",
+                    "button",
+                    "[data-radix-collection-item]",
+                    "li",
+                ];
+                const matches = [];
+                for (const selector of selectors) {
+                    for (const el of document.querySelectorAll(selector)) {
+                        if (!isVisible(el)) continue;
+                        const primaryText = ((el.innerText || el.textContent || "")
+                            .split(/\n+/)
+                            .map((part) => part.trim())
+                            .filter(Boolean)[0] || "").trim();
+                        const text = [
+                            primaryText,
+                            el.innerText || "",
+                            el.textContent || "",
+                            el.getAttribute("aria-label") || "",
+                            el.getAttribute("title") || "",
+                        ].join(" ").trim();
+                        const normalizedText = normalize(text);
+                        const normalizedPrimary = normalize(primaryText);
+                        if (!normalizedText || !normalizedText.includes(target)) continue;
+                        let score = 0;
+                        if (normalizedPrimary === target) score += 80;
+                        else if (normalizedText === target) score += 60;
+                        else if (normalizedPrimary.startsWith(target)) score += 45;
+                        else if (normalizedText.startsWith(target)) score += 40;
+                        else score += 20;
+                        const rect = el.getBoundingClientRect();
+                        if (rect.top < 700) score += 10;
+                        matches.push({ el, score, top: rect.top, left: rect.left });
+                    }
+                }
+                matches.sort((a, b) => b.score - a.score || a.top - b.top || a.left - b.left);
+                const best = matches[0];
+                if (!best) return false;
+                best.el.click();
+                return true;
+            }
+            """,
+            target_text,
+        )
+        return bool(clicked)
+
+    async def _wait_for_model_label(self, target_label: str) -> bool:
+        """Wait briefly until the current-model button reflects the requested label."""
+        deadline = time.time() + (Config.CHATGPT_MODEL_SWITCH_TIMEOUT / 1000.0)
+        target_normalized = normalize_model_token(target_label)
+        while time.time() < deadline:
+            current_label = await self._detect_current_model_label()
+            if normalize_model_token(current_label) == target_normalized:
+                return True
+            await asyncio.sleep(0.25)
         return False
 
     async def _upload_files(self, file_paths: list[str]) -> None:

--- a/src/chatgpt/model_registry.py
+++ b/src/chatgpt/model_registry.py
@@ -1,0 +1,114 @@
+"""
+Model registry helpers for browser-backed ChatGPT model switching.
+
+Maps public API model ids to the visible labels shown in ChatGPT's model picker.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from src.config import Config
+
+PUBLIC_BROWSER_MODEL_ID = "catgpt-browser"
+_AUTO_MODEL_IDS = {
+    "",
+    "auto",
+    "default",
+    "browser",
+    PUBLIC_BROWSER_MODEL_ID,
+}
+
+
+@dataclass(frozen=True)
+class BrowserModelOption:
+    """A public API model id paired with the ChatGPT UI label to click."""
+
+    public_id: str
+    ui_label: str
+
+
+def normalize_model_token(value: str) -> str:
+    """Normalize model ids / labels for resilient matching."""
+    return re.sub(r"[^a-z0-9]+", "", (value or "").strip().lower())
+
+
+def _parse_model_aliases(raw: str) -> list[BrowserModelOption]:
+    """Parse a comma-separated alias list like `gpt-5.3=GPT-5.3,o3=o3`."""
+    options: list[BrowserModelOption] = []
+    seen: set[str] = set()
+
+    for chunk in (raw or "").split(","):
+        item = chunk.strip()
+        if not item:
+            continue
+
+        if "=" in item:
+            public_id, ui_label = item.split("=", 1)
+        else:
+            public_id, ui_label = item, item
+
+        public_id = public_id.strip()
+        ui_label = ui_label.strip()
+        normalized = normalize_model_token(public_id)
+        if not public_id or not ui_label or not normalized or normalized in seen:
+            continue
+
+        options.append(BrowserModelOption(public_id=public_id, ui_label=ui_label))
+        seen.add(normalized)
+
+    return options
+
+
+def list_switchable_models() -> list[BrowserModelOption]:
+    """Return the configured explicit browser-switchable models."""
+    return _parse_model_aliases(Config.CHATGPT_MODEL_ALIASES)
+
+
+def list_public_chat_models() -> list[str]:
+    """Return public model ids exposed via `/v1/models`."""
+    model_ids = [PUBLIC_BROWSER_MODEL_ID]
+    model_ids.extend(option.public_id for option in list_switchable_models())
+    return model_ids
+
+
+def is_supported_chat_model(model: str) -> bool:
+    """Return whether a request model is supported by the browser gateway."""
+    normalized = normalize_model_token(model)
+    if normalized in {normalize_model_token(v) for v in _AUTO_MODEL_IDS}:
+        return True
+
+    for option in list_switchable_models():
+        if normalized in {
+            normalize_model_token(option.public_id),
+            normalize_model_token(option.ui_label),
+        }:
+            return True
+
+    return False
+
+
+def resolve_requested_model(model: str) -> BrowserModelOption | None:
+    """
+    Resolve the requested public model id to a ChatGPT UI label.
+
+    `catgpt-browser` and other auto aliases only trigger a model switch when
+    `CHATGPT_DEFAULT_MODEL` is configured to one of the explicit models.
+    """
+    normalized = normalize_model_token(model)
+    if normalized in {normalize_model_token(v) for v in _AUTO_MODEL_IDS}:
+        default_model = (Config.CHATGPT_DEFAULT_MODEL or "").strip()
+        if not default_model:
+            return None
+        normalized = normalize_model_token(default_model)
+
+    for option in list_switchable_models():
+        if normalized in {
+            normalize_model_token(option.public_id),
+            normalize_model_token(option.ui_label),
+        }:
+            return option
+
+    return None
+

--- a/src/config.py
+++ b/src/config.py
@@ -26,6 +26,12 @@ class Config:
     HEADLESS: bool = os.getenv("HEADLESS", "false").lower() == "true"
     SLOW_MO: int = int(os.getenv("SLOW_MO", "50"))
     CHATGPT_URL: str = os.getenv("CHATGPT_URL", "https://chatgpt.com")
+    CHATGPT_DEFAULT_MODEL: str = os.getenv("CHATGPT_DEFAULT_MODEL", "")
+    CHATGPT_MODEL_ALIASES: str = os.getenv(
+        "CHATGPT_MODEL_ALIASES",
+        "gpt-5.5=GPT-5.5,gpt-5.5-pro=GPT-5.5 pro,gpt-5.4=GPT-5.4,gpt-5.4-pro=GPT-5.4 pro,gpt-5.4-mini=GPT-5.4 mini,gpt-5.4-nano=GPT-5.4 nano,gpt-5-mini=GPT-5 mini,gpt-5-nano=GPT-5 nano,gpt-5=GPT-5,gpt-5.3=GPT-5.3,o3=o3,o4-mini=o4-mini,gpt-4.5=GPT-4.5,gpt-4.1=GPT-4.1,gpt-4.1-mini=GPT-4.1 mini,gpt-4o=GPT-4o",
+    )
+    CHATGPT_MODEL_SWITCH_TIMEOUT: int = int(os.getenv("CHATGPT_MODEL_SWITCH_TIMEOUT", "10000"))
 
     # Timeouts (ms)
     RESPONSE_TIMEOUT: int = int(os.getenv("RESPONSE_TIMEOUT", "120000"))

--- a/src/selectors.py
+++ b/src/selectors.py
@@ -26,6 +26,11 @@ class Selectors:
         "#prompt-textarea ~ button",
     ]
 
+    # Model picker trigger in ChatGPT's composer/header.
+    MODEL_PICKER_BUTTON = [
+        "button[data-testid='model-switcher-dropdown-button']",
+    ]
+
     # ── Assistant response messages ─────────────────────────────
     ASSISTANT_MESSAGE = [
         "div[data-message-author-role='assistant']",

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from src.chatgpt import model_registry
+
+
+class ModelRegistryTests(unittest.TestCase):
+    def test_public_models_include_browser_alias_and_configured_models(self) -> None:
+        with patch.object(model_registry.Config, "CHATGPT_MODEL_ALIASES", "gpt-5.3=GPT-5.3,o3=o3"):
+            self.assertEqual(
+                model_registry.list_public_chat_models(),
+                ["catgpt-browser", "gpt-5.3", "o3"],
+            )
+
+    def test_supported_model_accepts_public_id_and_ui_label(self) -> None:
+        with patch.object(model_registry.Config, "CHATGPT_MODEL_ALIASES", "gpt-4.1-mini=GPT-4.1 mini"):
+            self.assertTrue(model_registry.is_supported_chat_model("gpt-4.1-mini"))
+            self.assertTrue(model_registry.is_supported_chat_model("GPT-4.1 mini"))
+
+    def test_resolve_requested_model_uses_default_for_browser_alias(self) -> None:
+        with patch.object(model_registry.Config, "CHATGPT_MODEL_ALIASES", "gpt-5.3=GPT-5.3,o3=o3"), patch.object(
+            model_registry.Config,
+            "CHATGPT_DEFAULT_MODEL",
+            "o3",
+        ):
+            resolved = model_registry.resolve_requested_model("catgpt-browser")
+            self.assertIsNotNone(resolved)
+            assert resolved is not None
+            self.assertEqual(resolved.public_id, "o3")
+            self.assertEqual(resolved.ui_label, "o3")
+
+    def test_resolve_requested_model_returns_none_for_browser_alias_without_default(self) -> None:
+        with patch.object(model_registry.Config, "CHATGPT_MODEL_ALIASES", "gpt-5.3=GPT-5.3"), patch.object(
+            model_registry.Config,
+            "CHATGPT_DEFAULT_MODEL",
+            "",
+        ):
+            self.assertIsNone(model_registry.resolve_requested_model("catgpt-browser"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openai_routes_helpers.py
+++ b/tests/test_openai_routes_helpers.py
@@ -5,6 +5,7 @@ import types
 import unittest
 
 from starlette.requests import Request
+from fastapi import HTTPException
 
 # Provide a minimal patchright stub so helper tests can import API modules
 # without requiring browser automation dependencies.
@@ -42,6 +43,7 @@ from src.api.openai_routes import (
     _looks_like_instruction_prefix,
     _merge_header_rows_in_array,
     _should_use_line_cardinality_fallback,
+    _validate_chat_request,
 )
 from src.api.openai_schemas import ChatCompletionRequest, ChatMessage
 
@@ -190,6 +192,16 @@ class OpenAIRoutesHelpersTests(unittest.TestCase):
         assert detected is not None
         _, tail = detected
         self.assertEqual(tail, "B" * 1500)
+
+    def test_validate_chat_request_rejects_unsupported_model(self) -> None:
+        req = ChatCompletionRequest(
+            model="not-a-real-model",
+            messages=[ChatMessage(role="user", content="hello")],
+        )
+        with self.assertRaises(HTTPException) as ctx:
+            _validate_chat_request(req)
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("Unsupported model", ctx.exception.detail)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a configurable browser model registry and expose supported chat models via /v1/models
- switch the ChatGPT web UI automatically before send when a supported model is requested
- validate requested models in both OpenAI-compatible and native REST routes, and document the new config

## Testing
- .\\.venv\\Scripts\\python -m unittest discover -s tests
- .\\.venv\\Scripts\\python -m compileall src tests