### PR TITLE
Add Ollama compatibility and multi-page OCR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 CatGPT automates a real browser session with ChatGPT, letting you:
 
 - **Use ChatGPT as an OpenAI-compatible API** — drop-in replacement for `openai.ChatCompletion.create()`
+- **Use ChatGPT as an Ollama-compatible API** — supports common `/api/*` endpoints for Ollama-based clients
 - **Tool / Function calling** — full round-trip support (define tools → model calls them → send results back)
 - **Send images** — OpenAI vision format (`image_url` with base64 data URLs or HTTP URLs)
 - **Send file attachments** — PDF, DOCX, TXT, CSV, etc. via a custom `file` content type
@@ -217,6 +218,31 @@ Base URL: `http://localhost:8000/v1` — **Model ID:** `catgpt-browser`
 | `POST` | `/{app_name}/v1/images/generations` | App-scoped image generation                                        |
 | `GET`  | `/{app_name}/v1/models` | App-scoped model list                                                       |
 
+### Ollama-Compatible Endpoints
+
+CatGPT also exposes a compatibility layer for Ollama-oriented clients such as
+Open WebUI. Chat and generation requests are routed into the same browser-backed
+ChatGPT executor used by the OpenAI-compatible API.
+
+`/api/embed` is implemented as a deterministic compatibility embedding shim so
+clients that require the endpoint can function, but it is not a semantic
+embedding model suitable for production-quality retrieval or RAG ranking.
+
+| Method | Path                     | Description |
+| ------ | ------------------------ | ----------- |
+| `POST` | `/api/chat`              | Ollama-compatible chat mapping |
+| `POST` | `/api/generate`          | Ollama-compatible text generation mapping |
+| `POST` | `/api/embed`             | Ollama-compatible embedding shim |
+| `GET`  | `/api/tags`              | List configured model profiles |
+| `POST` | `/api/show`              | Return static metadata for a model |
+| `GET`  | `/api/ps`                | List recently active models |
+| `POST` | `/api/pull`              | Safety mock for configured models |
+| `DELETE` | `/api/delete`          | Safety mock delete success |
+| `POST` | `/api/copy`              | Unsupported mock response |
+
+Every Ollama endpoint is also available under the app-scoped `/{app_name}/api/*`
+prefix for consistency with app-thread routing.
+
 ### Custom REST Endpoints
 
 | Method | Path                | Description                                   |
@@ -236,6 +262,8 @@ Base URL: `http://localhost:8000/v1` — **Model ID:** `catgpt-browser`
 > **Streaming note:** `/v1/chat/completions` actively rejects `stream=true` with a 400 error. This is a fundamental limitation since the browser waits for the full ChatGPT response before returning.
 
 > **Structured output note:** `response_format` is supported for `/v1/chat/completions` and `/v1/chat/completions/async` (including `json_object` and `json_schema`).
+
+> **Per-page OCR note:** set `page_extraction={"mode":"structured"}` on `/v1/chat/completions` or `/v1/chat/completions/async` to force attachment OCR/document extraction into a strict JSON `pages` array with one item per rendered page. This mode manages `response_format` automatically.
 
 > **Response cache note:** `/v1/chat/completions` now includes an in-memory dedup cache for identical requests (TTL: 600s, max entries: 256). Cache hits return a fresh OpenAI-style response envelope (`id`, `created`) with cached content.
 
@@ -429,6 +457,31 @@ print(response.choices[0].message.content)
 
 CatGPT supports arbitrary file attachments via a custom `file` content type:
 
+Multi-page PDFs and multi-frame images (for example TIFF) are expanded into
+ordered page images automatically before upload so ChatGPT can see the full
+document, not just the first page/frame. For large document jobs, prefer
+`POST /v1/chat/completions/async` to avoid long-lived request timeouts.
+
+If you want structured OCR-style output instead of a free-form answer, add
+`"page_extraction": {"mode": "structured"}` to the request body. CatGPT will
+force a JSON response shaped like:
+
+```json
+{
+  "pages": [
+    {
+      "page_index": 1,
+      "source_name": "document.pdf",
+      "page_number": 1,
+      "text": "..."
+    }
+  ]
+}
+```
+
+Each `pages` item maps to one rendered page in upload order. Blank/unreadable
+pages are kept with an empty `text` string instead of being dropped.
+
 ```python
 import base64
 from openai import OpenAI
@@ -453,7 +506,8 @@ response = client.chat.completions.create(
                 }
             },
         ]
-    }]
+    }],
+    page_extraction={"mode": "structured"},
 )
 ```
 
@@ -602,6 +656,12 @@ All settings are loaded from environment variables (`.env` file or `docker-compo
 | `CHATGPT_DEFAULT_MODEL` | ``                  | Optional model id to auto-apply when requests use `catgpt-browser` |
 | `CHATGPT_MODEL_ALIASES` | `gpt-5.3=GPT-5.3,...` | Comma-separated `public_id=UI label` map for browser model switching |
 | `CHATGPT_MODEL_SWITCH_TIMEOUT` | `10000`     | Max wait time (ms) to confirm the ChatGPT UI switched models |
+| `ATTACHMENT_EXPAND_MULTIPAGE` | `true`      | If `true`, expands multi-page PDFs and multi-frame images into ordered page images before upload |
+| `ATTACHMENT_MAX_PAGES` | `24`                | Maximum pages/frames rendered from a single attachment |
+| `ATTACHMENT_RENDER_DPI` | `144`              | DPI used when rendering PDF pages to images |
+| `OLLAMA_EMBEDDING_MODELS` | `nomic-embed-text` | Comma-separated Ollama-visible embedding model profiles |
+| `OLLAMA_EMBEDDING_DIMENSIONS` | `768`       | Vector size used by the compatibility embedding shim |
+| `OLLAMA_ACTIVE_MODEL_TTL_SECONDS` | `900`   | How long a model remains listed in `/api/ps` after use |
 | `RESPONSE_TIMEOUT`   | `120000`              | Max wait for ChatGPT response (ms)                       |
 | `SELECTOR_TIMEOUT`   | `5000`                | Timeout per selector probe (ms)                          |
 | `TYPE_DELAY_MIN`     | `50`                  | Min delay between keystrokes (ms)                        |

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ uvicorn>=0.46.0
 # Data & Config
 pydantic>=2.13.3
 python-dotenv>=1.2.2
+Pillow>=11.2.1
+PyMuPDF>=1.26.0
 
 # OpenAI-compatible testing
 openai>=2.32.0

--- a/src/api/attachment_expander.py
+++ b/src/api/attachment_expander.py
@@ -1,0 +1,303 @@
+"""
+Helpers for expanding multi-page attachments into ordered page images.
+
+This keeps the browser-upload path simple while ensuring ChatGPT sees every page
+of a PDF or multi-frame image instead of only the first page/frame.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from src.config import Config
+from src.log import setup_logging
+
+log = setup_logging("attachment_expander")
+
+
+@dataclass
+class AttachmentExpansionResult:
+    """Expanded attachment paths plus prompt notes for page ordering/failures."""
+
+    image_paths: list[str] = field(default_factory=list)
+    file_paths: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    page_descriptors: list["AttachmentPageDescriptor"] = field(default_factory=list)
+    total_rendered_pages: int = 0
+
+
+@dataclass
+class AttachmentPageDescriptor:
+    """Metadata describing one logical page/item the model should extract."""
+
+    source_name: str
+    page_number: int
+    page_index: int = 0
+    upload_kind: str = "image"
+    source_kind: str = "image"
+
+
+def expand_attachments_for_chatgpt(
+    image_paths: list[str] | None,
+    file_paths: list[str] | None,
+) -> AttachmentExpansionResult:
+    """
+    Expand multi-page PDFs and multi-frame images into individual page images.
+
+    Rendering is done sequentially and page failures are isolated so one bad page
+    does not abort the whole job.
+    """
+    result = AttachmentExpansionResult()
+    if not Config.ATTACHMENT_EXPAND_MULTIPAGE:
+        result.image_paths = list(image_paths or [])
+        result.file_paths = list(file_paths or [])
+        for image_path in result.image_paths:
+            result.page_descriptors.append(
+                _build_page_descriptor(image_path, page_number=1, upload_kind="image", source_kind="image")
+            )
+        for file_path in result.file_paths:
+            result.page_descriptors.append(
+                _build_page_descriptor(file_path, page_number=1, upload_kind="file", source_kind=_source_kind_for_file(file_path))
+            )
+        _assign_page_indexes(result.page_descriptors)
+        return result
+
+    for image_path in image_paths or []:
+        expansion = _expand_multiframe_image(image_path)
+        if expansion is None:
+            result.image_paths.append(image_path)
+            result.page_descriptors.append(
+                _build_page_descriptor(image_path, page_number=1, upload_kind="image", source_kind="image")
+            )
+            continue
+
+        result.image_paths.extend(expansion["image_paths"])
+        result.image_paths.extend(expansion["fallback_image_paths"])
+        result.notes.extend(expansion["notes"])
+        result.page_descriptors.extend(expansion["page_descriptors"])
+        result.total_rendered_pages += expansion["rendered_pages"]
+
+    for file_path in file_paths or []:
+        if Path(file_path).suffix.lower() != ".pdf":
+            result.file_paths.append(file_path)
+            result.page_descriptors.append(
+                _build_page_descriptor(file_path, page_number=1, upload_kind="file", source_kind=_source_kind_for_file(file_path))
+            )
+            continue
+
+        expansion = _expand_pdf(file_path)
+        if expansion is None:
+            result.file_paths.append(file_path)
+            result.page_descriptors.append(
+                _build_page_descriptor(file_path, page_number=1, upload_kind="file", source_kind="pdf")
+            )
+            continue
+
+        result.image_paths.extend(expansion["image_paths"])
+        result.file_paths.extend(expansion["fallback_file_paths"])
+        result.notes.extend(expansion["notes"])
+        result.page_descriptors.extend(expansion["page_descriptors"])
+        result.total_rendered_pages += expansion["rendered_pages"]
+
+    _assign_page_indexes(result.page_descriptors)
+    return result
+
+
+def build_attachment_context_note(notes: list[str]) -> str:
+    """Build a compact prompt preface describing rendered page ordering."""
+    if not notes:
+        return ""
+
+    lines = ["[Attachment processing]"]
+    lines.extend(f"- {note}" for note in notes)
+    lines.append("- Treat rendered page images as ordered pages of the same source document.")
+    return "\n".join(lines) + "\n\n"
+
+
+def _expand_pdf(path: str) -> dict | None:
+    """Render a PDF to page images. Returns None if the file should pass through unchanged."""
+    try:
+        import fitz  # type: ignore
+    except ImportError:
+        log.warning("PyMuPDF is not installed; passing PDF through unchanged: %s", path)
+        return None
+
+    pdf_path = Path(path)
+    output_dir = str(pdf_path.parent)
+    rendered_paths: list[str] = []
+    failed_pages: list[int] = []
+    page_descriptors: list[AttachmentPageDescriptor] = []
+
+    try:
+        doc = fitz.open(path)
+    except Exception as e:
+        log.warning("Failed to open PDF for page expansion (%s): %s", path, e)
+        return None
+    try:
+        page_count = doc.page_count
+        if page_count <= 1:
+            return None
+
+        max_pages = max(1, min(page_count, Config.ATTACHMENT_MAX_PAGES))
+        scale = max(1.0, Config.ATTACHMENT_RENDER_DPI / 72.0)
+        matrix = fitz.Matrix(scale, scale)
+
+        for page_index in range(max_pages):
+            page_number = page_index + 1
+            try:
+                page = doc.load_page(page_index)
+                pix = page.get_pixmap(matrix=matrix, alpha=False)
+                output_path = _page_output_path(pdf_path, output_dir, page_number)
+                pix.save(output_path)
+                rendered_paths.append(output_path)
+                page_descriptors.append(
+                    AttachmentPageDescriptor(
+                        source_name=pdf_path.name,
+                        page_number=page_number,
+                        upload_kind="image",
+                        source_kind="pdf",
+                    )
+                )
+            except Exception as e:
+                log.warning("Failed to render PDF page %s from %s: %s", page_number, path, e)
+                failed_pages.append(page_number)
+    finally:
+        doc.close()
+
+    if not rendered_paths:
+        return None
+
+    notes = [_build_render_note(pdf_path.name, "page", len(rendered_paths), failed_pages, page_count)]
+    fallback_files: list[str] = []
+    if failed_pages:
+        fallback_files.append(path)
+        notes.append(f"Kept original PDF '{pdf_path.name}' as a fallback because some pages failed to render.")
+
+    return {
+        "image_paths": rendered_paths,
+        "fallback_file_paths": fallback_files,
+        "notes": notes,
+        "page_descriptors": page_descriptors,
+        "rendered_pages": len(rendered_paths),
+    }
+
+
+def _expand_multiframe_image(path: str) -> dict | None:
+    """Expand a multi-frame image (TIFF/GIF/WebP) into ordered PNG page images."""
+    try:
+        from PIL import Image, ImageSequence, UnidentifiedImageError  # type: ignore
+    except ImportError:
+        log.debug("Pillow is not installed; skipping multi-frame expansion for %s", path)
+        return None
+
+    image_path = Path(path)
+    output_dir = str(image_path.parent)
+    rendered_paths: list[str] = []
+    failed_pages: list[int] = []
+    page_descriptors: list[AttachmentPageDescriptor] = []
+
+    try:
+        with Image.open(path) as image:
+            frame_count = getattr(image, "n_frames", 1)
+            if frame_count <= 1:
+                return None
+
+            max_pages = max(1, min(frame_count, Config.ATTACHMENT_MAX_PAGES))
+            for frame_index, frame in enumerate(ImageSequence.Iterator(image), start=1):
+                if frame_index > max_pages:
+                    break
+                try:
+                    output_path = _page_output_path(image_path, output_dir, frame_index)
+                    frame.convert("RGB").save(output_path, format="PNG")
+                    rendered_paths.append(output_path)
+                    page_descriptors.append(
+                        AttachmentPageDescriptor(
+                            source_name=image_path.name,
+                            page_number=frame_index,
+                            upload_kind="image",
+                            source_kind="image",
+                        )
+                    )
+                except Exception as e:
+                    log.warning("Failed to render image frame %s from %s: %s", frame_index, path, e)
+                    failed_pages.append(frame_index)
+    except UnidentifiedImageError:
+        return None
+    except Exception as e:
+        log.warning("Failed to open image for frame expansion (%s): %s", path, e)
+        return None
+
+    if not rendered_paths:
+        return None
+
+    notes = [_build_render_note(image_path.name, "frame", len(rendered_paths), failed_pages, frame_count)]
+    fallback_images: list[str] = []
+    if failed_pages:
+        fallback_images.append(path)
+        notes.append(f"Kept original image '{image_path.name}' as a fallback because some frames failed to render.")
+
+    return {
+        "image_paths": rendered_paths,
+        "fallback_image_paths": fallback_images,
+        "notes": notes,
+        "page_descriptors": page_descriptors,
+        "rendered_pages": len(rendered_paths),
+    }
+
+
+def _page_output_path(source_path: Path, output_dir: str, page_number: int) -> str:
+    """Build a stable page-image output path next to the downloaded source file."""
+    stem = re.sub(r"[^\w.\-]", "_", source_path.stem)
+    return os.path.join(output_dir, f"{stem}_page_{page_number:03d}.png")
+
+
+def _build_page_descriptor(
+    path: str,
+    page_number: int,
+    upload_kind: str,
+    source_kind: str,
+) -> AttachmentPageDescriptor:
+    """Build a logical page descriptor for a passthrough attachment."""
+    source_name = Path(path).name or "attachment"
+    return AttachmentPageDescriptor(
+        source_name=source_name,
+        page_number=page_number,
+        upload_kind=upload_kind,
+        source_kind=source_kind,
+    )
+
+
+def _assign_page_indexes(page_descriptors: list[AttachmentPageDescriptor]) -> None:
+    """Assign stable 1-based indexes matching the page-map order exposed to the model."""
+    for index, descriptor in enumerate(page_descriptors, start=1):
+        descriptor.page_index = index
+
+
+def _source_kind_for_file(path: str) -> str:
+    """Infer a coarse source kind from the file extension."""
+    ext = Path(path).suffix.lower()
+    if ext == ".pdf":
+        return "pdf"
+    if ext in {".gif", ".jpg", ".jpeg", ".png", ".tif", ".tiff", ".webp"}:
+        return "image"
+    return "file"
+
+
+def _build_render_note(
+    source_name: str,
+    unit_name: str,
+    rendered_count: int,
+    failed_pages: list[int],
+    total_count: int,
+) -> str:
+    """Describe rendered page/frame coverage for the prompt prefix."""
+    note = f"Expanded '{source_name}' into {rendered_count} ordered {unit_name} image(s)."
+    if total_count > Config.ATTACHMENT_MAX_PAGES:
+        note += f" Limited to the first {Config.ATTACHMENT_MAX_PAGES} of {total_count} {unit_name}s."
+    if failed_pages:
+        joined = ", ".join(str(page) for page in failed_pages)
+        note += f" Skipped {unit_name}(s): {joined}."
+    return note

--- a/src/api/browser_gate.py
+++ b/src/api/browser_gate.py
@@ -1,0 +1,14 @@
+"""
+Shared browser-access coordination primitives.
+
+Today CatGPT drives a single ChatGPT page, so every API surface that touches
+that page must serialize against the same lock. Keeping the lock in one module
+avoids route families accidentally using separate "global" locks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+# Single-process browser access lock for the shared ChatGPT page.
+browser_access_lock = asyncio.Lock()

--- a/src/api/ollama_registry.py
+++ b/src/api/ollama_registry.py
@@ -1,0 +1,283 @@
+"""
+Ollama compatibility registry and metadata helpers.
+
+Provides a stable read-only model registry, deterministic digests, lightweight
+active-model tracking, and a deterministic embedding fallback for clients that
+expect Ollama endpoints.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import time
+from dataclasses import dataclass
+
+from src.chatgpt.model_registry import list_public_chat_models, normalize_model_token
+from src.config import Config
+
+_STATIC_CREATED_AT = "2026-05-04T00:00:00Z"
+_active_models: dict[str, float] = {}
+
+
+@dataclass(frozen=True)
+class OllamaModelProfile:
+    """Static profile used by the Ollama compatibility endpoints."""
+
+    name: str
+    capability: str
+    display_family: str
+    parameter_size: str
+    quantization_level: str
+    size: int
+    digest: str
+
+
+def list_ollama_profiles() -> list[OllamaModelProfile]:
+    """Return all configured Ollama-visible profiles."""
+    profiles: list[OllamaModelProfile] = []
+    seen: set[str] = set()
+
+    for model in list_public_chat_models():
+        normalized = normalize_model_token(model)
+        if normalized in seen:
+            continue
+        profiles.append(_build_profile(model, capability="chat"))
+        seen.add(normalized)
+
+    for model in _parse_embedding_models(Config.OLLAMA_EMBEDDING_MODELS):
+        normalized = normalize_model_token(model)
+        if normalized in seen:
+            continue
+        profiles.append(_build_profile(model, capability="embedding"))
+        seen.add(normalized)
+
+    return profiles
+
+
+def get_ollama_profile(name: str) -> OllamaModelProfile | None:
+    """Resolve a profile by model name, case-insensitively."""
+    target = normalize_model_token(name)
+    for profile in list_ollama_profiles():
+        if normalize_model_token(profile.name) == target:
+            return profile
+    return None
+
+
+def list_tags_payload() -> dict:
+    """Payload for GET /api/tags."""
+    return {
+        "models": [build_tag_entry(profile) for profile in list_ollama_profiles()],
+    }
+
+
+def build_tag_entry(profile: OllamaModelProfile) -> dict:
+    """Single tag entry in Ollama's model list shape."""
+    return {
+        "name": profile.name,
+        "model": profile.name,
+        "modified_at": _STATIC_CREATED_AT,
+        "size": profile.size,
+        "digest": profile.digest,
+        "details": _details_dict(profile),
+    }
+
+
+def build_show_payload(profile: OllamaModelProfile) -> dict:
+    """Static metadata for POST /api/show."""
+    return {
+        "license": "Proprietary browser-backed compatibility profile.",
+        "modelfile": _build_modelfile(profile),
+        "parameters": _build_parameters(profile),
+        "template": "{{ .Prompt }}",
+        "system": "",
+        "details": _details_dict(profile),
+        "model_info": {
+            "general.architecture": "catgpt-browser",
+            "general.parameter_count": profile.parameter_size,
+            "general.quantization_version": profile.quantization_level,
+            "general.capability": profile.capability,
+            "general.embedding_dimensions": (
+                Config.OLLAMA_EMBEDDING_DIMENSIONS if profile.capability == "embedding" else 0
+            ),
+        },
+        "capabilities": [profile.capability],
+        "modified_at": _STATIC_CREATED_AT,
+        "digest": profile.digest,
+    }
+
+
+def mark_model_active(name: str) -> None:
+    """Mark a model as recently used for /api/ps."""
+    profile = get_ollama_profile(name)
+    if profile is None:
+        return
+    _active_models[profile.name] = time.time()
+
+
+def list_active_models_payload() -> dict:
+    """Payload for POST /api/ps."""
+    now = time.time()
+    ttl = max(1, Config.OLLAMA_ACTIVE_MODEL_TTL_SECONDS)
+    expired = [name for name, ts in _active_models.items() if now - ts > ttl]
+    for name in expired:
+        _active_models.pop(name, None)
+
+    models = []
+    for name, last_used in sorted(_active_models.items(), key=lambda item: item[1], reverse=True):
+        profile = get_ollama_profile(name)
+        if profile is None:
+            continue
+        models.append({
+            "name": profile.name,
+            "model": profile.name,
+            "size": profile.size,
+            "digest": profile.digest,
+            "details": _details_dict(profile),
+            "expires_at": _iso_ts(last_used + ttl),
+            "size_vram": max(0, profile.size // 2),
+        })
+
+    return {"models": models}
+
+
+def build_pull_status_payload(name: str) -> dict:
+    """Success payload for POST /api/pull when the model exists in the registry."""
+    profile = get_ollama_profile(name)
+    if profile is None:
+        raise KeyError(name)
+    mark_model_active(profile.name)
+    return {
+        "status": "success",
+        "digest": profile.digest,
+        "total": profile.size,
+        "completed": profile.size,
+    }
+
+
+def build_delete_status_payload(name: str) -> dict:
+    """Success payload for DELETE /api/delete safety mock."""
+    return {
+        "status": "success",
+        "deleted": name,
+        "mocked": True,
+    }
+
+
+def build_copy_unsupported_payload(source: str, destination: str) -> dict:
+    """Unsupported payload for POST /api/copy."""
+    return {
+        "error": f"Copy is not supported for browser-backed model '{source}' -> '{destination}'.",
+    }
+
+
+def generate_embeddings(name: str, inputs: list[str]) -> dict:
+    """
+    Deterministic embedding fallback for Ollama-compatible clients.
+
+    This is a compatibility shim, not a semantic embedding model.
+    """
+    profile = get_ollama_profile(name)
+    if profile is None:
+        raise KeyError(name)
+
+    mark_model_active(profile.name)
+    vectors = [_embedding_vector(profile.name, text, Config.OLLAMA_EMBEDDING_DIMENSIONS) for text in inputs]
+    return {
+        "model": profile.name,
+        "embeddings": vectors,
+        "total_duration": 0,
+        "load_duration": 0,
+        "prompt_eval_count": sum(len(text) for text in inputs),
+    }
+
+
+def _parse_embedding_models(raw: str) -> list[str]:
+    values: list[str] = []
+    for chunk in (raw or "").split(","):
+        item = chunk.strip()
+        if item:
+            values.append(item)
+    return values
+
+
+def _build_profile(name: str, capability: str) -> OllamaModelProfile:
+    digest = _digest_for_model(name)
+    size = _stable_size_bytes(name, capability)
+    parameter_size = "browser-managed" if capability == "chat" else f"{Config.OLLAMA_EMBEDDING_DIMENSIONS}d"
+    quantization = "compat" if capability == "chat" else "compat-embed"
+    family = "catgpt-browser" if capability == "chat" else "catgpt-embed"
+    return OllamaModelProfile(
+        name=name,
+        capability=capability,
+        display_family=family,
+        parameter_size=parameter_size,
+        quantization_level=quantization,
+        size=size,
+        digest=digest,
+    )
+
+
+def _digest_for_model(name: str) -> str:
+    return f"sha256:{hashlib.sha256(f'ollama:{name}'.encode('utf-8')).hexdigest()}"
+
+
+def _stable_size_bytes(name: str, capability: str) -> int:
+    digest = hashlib.sha256(f"size:{capability}:{name}".encode("utf-8")).digest()
+    seed = int.from_bytes(digest[:4], "big")
+    if capability == "embedding":
+        base = 256 * 1024 * 1024
+        span = 768 * 1024 * 1024
+    else:
+        base = 2 * 1024 * 1024 * 1024
+        span = 6 * 1024 * 1024 * 1024
+    return base + (seed % span)
+
+
+def _build_modelfile(profile: OllamaModelProfile) -> str:
+    return (
+        f"FROM {profile.name}\n"
+        f"# capability: {profile.capability}\n"
+        "# backend: ChatGPT browser automation compatibility layer\n"
+    )
+
+
+def _build_parameters(profile: OllamaModelProfile) -> str:
+    if profile.capability == "embedding":
+        return f"embedding_dimensions {Config.OLLAMA_EMBEDDING_DIMENSIONS}\ntruncate false"
+    return "num_ctx 32768\nnum_predict 4096"
+
+
+def _details_dict(profile: OllamaModelProfile) -> dict:
+    return {
+        "parent_model": "",
+        "format": "compat",
+        "family": profile.display_family,
+        "families": [profile.display_family],
+        "parameter_size": profile.parameter_size,
+        "quantization_level": profile.quantization_level,
+    }
+
+
+def _embedding_vector(model_name: str, text: str, dimensions: int) -> list[float]:
+    dims = max(8, dimensions)
+    values: list[float] = []
+    counter = 0
+
+    while len(values) < dims:
+        payload = f"{model_name}\n{counter}\n{text}".encode("utf-8")
+        digest = hashlib.sha256(payload).digest()
+        for index in range(0, len(digest), 2):
+            if len(values) >= dims:
+                break
+            raw = int.from_bytes(digest[index:index + 2], "big") / 65535.0
+            values.append((raw * 2.0) - 1.0)
+        counter += 1
+
+    norm = math.sqrt(sum(v * v for v in values)) or 1.0
+    return [round(v / norm, 8) for v in values]
+
+
+def _iso_ts(value: float) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(value))
+

--- a/src/api/ollama_routes.py
+++ b/src/api/ollama_routes.py
@@ -1,0 +1,398 @@
+"""
+Ollama-compatible API routes layered on top of the existing ChatGPT backend.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterable
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from src.api.ollama_registry import (
+    build_copy_unsupported_payload,
+    build_delete_status_payload,
+    build_pull_status_payload,
+    build_show_payload,
+    generate_embeddings,
+    get_ollama_profile,
+    list_active_models_payload,
+    list_tags_payload,
+    mark_model_active,
+)
+from src.api.ollama_schemas import (
+    OllamaChatMessage,
+    OllamaChatRequest,
+    OllamaCopyRequest,
+    OllamaDeleteRequest,
+    OllamaEmbedRequest,
+    OllamaGenerateRequest,
+    OllamaPullRequest,
+    OllamaShowRequest,
+)
+from src.api.openai_routes import (
+    _execute_chat_completion,
+    _resolve_app_key,
+    _validate_chat_request,
+)
+from src.api.openai_schemas import ChatCompletionRequest, ChatMessage
+from src.log import setup_logging
+
+log = setup_logging("ollama_routes")
+
+ollama_router = APIRouter()
+
+
+@ollama_router.get("/api/tags")
+async def ollama_tags() -> dict:
+    """List configured Ollama-visible model profiles."""
+    return list_tags_payload()
+
+
+@ollama_router.get("/{app_name}/api/tags")
+async def ollama_tags_scoped(app_name: str) -> dict:
+    _ = app_name
+    return list_tags_payload()
+
+
+@ollama_router.post("/api/show")
+async def ollama_show(request: OllamaShowRequest) -> dict:
+    """Return static metadata for a configured model profile."""
+    profile = _require_profile(request.model)
+    return build_show_payload(profile)
+
+
+@ollama_router.post("/{app_name}/api/show")
+async def ollama_show_scoped(app_name: str, request: OllamaShowRequest) -> dict:
+    _ = app_name
+    return await ollama_show(request)
+
+
+@ollama_router.get("/api/ps")
+async def ollama_ps() -> dict:
+    """Return recently active models."""
+    return list_active_models_payload()
+
+
+@ollama_router.post("/api/ps")
+async def ollama_ps_post() -> dict:
+    """Ollama clients sometimes POST here; keep it compatible."""
+    return list_active_models_payload()
+
+
+@ollama_router.get("/{app_name}/api/ps")
+async def ollama_ps_scoped(app_name: str) -> dict:
+    _ = app_name
+    return list_active_models_payload()
+
+
+@ollama_router.post("/{app_name}/api/ps")
+async def ollama_ps_scoped_post(app_name: str) -> dict:
+    _ = app_name
+    return list_active_models_payload()
+
+
+@ollama_router.post("/api/chat")
+async def ollama_chat(
+    request: OllamaChatRequest,
+    http_request: Request,
+) -> Response:
+    """Map Ollama chat requests to the existing OpenAI-compatible backend."""
+    profile = _require_profile(request.model, capability="chat")
+    openai_request = _chat_request_from_ollama(request)
+    _validate_chat_request(openai_request)
+    app_key = _resolve_app_key(openai_request, http_request)
+    started_at = time.time()
+    response = await _execute_chat_completion(openai_request, app_key_override=app_key)
+    mark_model_active(profile.name)
+    return _ollama_chat_response(response, started_at, stream=request.stream)
+
+
+@ollama_router.post("/{app_name}/api/chat")
+async def ollama_chat_scoped(
+    app_name: str,
+    request: OllamaChatRequest,
+    http_request: Request,
+) -> Response:
+    profile = _require_profile(request.model, capability="chat")
+    openai_request = _chat_request_from_ollama(request)
+    _validate_chat_request(openai_request)
+    app_key = _resolve_app_key(openai_request, http_request, endpoint_app_name=app_name)
+    started_at = time.time()
+    response = await _execute_chat_completion(openai_request, app_key_override=app_key)
+    mark_model_active(profile.name)
+    return _ollama_chat_response(response, started_at, stream=request.stream)
+
+
+@ollama_router.post("/api/generate")
+async def ollama_generate(
+    request: OllamaGenerateRequest,
+    http_request: Request,
+) -> Response:
+    """Map Ollama text generation requests to the existing chat backend."""
+    profile = _require_profile(request.model, capability="chat")
+    openai_request = _generate_request_from_ollama(request)
+    _validate_chat_request(openai_request)
+    app_key = _resolve_app_key(openai_request, http_request)
+    started_at = time.time()
+    response = await _execute_chat_completion(openai_request, app_key_override=app_key)
+    mark_model_active(profile.name)
+    return _ollama_generate_response(response, started_at, stream=request.stream)
+
+
+@ollama_router.post("/{app_name}/api/generate")
+async def ollama_generate_scoped(
+    app_name: str,
+    request: OllamaGenerateRequest,
+    http_request: Request,
+) -> Response:
+    profile = _require_profile(request.model, capability="chat")
+    openai_request = _generate_request_from_ollama(request)
+    _validate_chat_request(openai_request)
+    app_key = _resolve_app_key(openai_request, http_request, endpoint_app_name=app_name)
+    started_at = time.time()
+    response = await _execute_chat_completion(openai_request, app_key_override=app_key)
+    mark_model_active(profile.name)
+    return _ollama_generate_response(response, started_at, stream=request.stream)
+
+
+@ollama_router.post("/api/embed")
+async def ollama_embed(request: OllamaEmbedRequest) -> dict:
+    """Return deterministic compatibility embeddings for configured models."""
+    _require_profile(request.model)
+    inputs = request.input if isinstance(request.input, list) else [request.input]
+    return generate_embeddings(request.model, inputs)
+
+
+@ollama_router.post("/{app_name}/api/embed")
+async def ollama_embed_scoped(app_name: str, request: OllamaEmbedRequest) -> dict:
+    _ = app_name
+    return await ollama_embed(request)
+
+
+@ollama_router.post("/api/embeddings")
+async def ollama_embeddings_legacy(request: OllamaEmbedRequest) -> dict:
+    """Legacy Ollama embeddings alias."""
+    return await ollama_embed(request)
+
+
+@ollama_router.post("/{app_name}/api/embeddings")
+async def ollama_embeddings_legacy_scoped(app_name: str, request: OllamaEmbedRequest) -> dict:
+    _ = app_name
+    return await ollama_embed(request)
+
+
+@ollama_router.post("/api/pull")
+async def ollama_pull(request: OllamaPullRequest) -> Response:
+    """Safety mock that succeeds for models present in our registry."""
+    _require_profile(request.model)
+    payload = build_pull_status_payload(request.model)
+    if request.stream:
+        return _ndjson_response([payload])
+    return JSONResponse(payload, media_type="application/json")
+
+
+@ollama_router.post("/{app_name}/api/pull")
+async def ollama_pull_scoped(app_name: str, request: OllamaPullRequest) -> Response:
+    _ = app_name
+    return await ollama_pull(request)
+
+
+@ollama_router.delete("/api/delete")
+async def ollama_delete(request: OllamaDeleteRequest) -> dict:
+    """Mock delete success so Ollama-based UIs don't error on unsupported ops."""
+    name = request.model or request.name or ""
+    if not name:
+        raise HTTPException(status_code=400, detail="model or name is required")
+    return build_delete_status_payload(name)
+
+
+@ollama_router.delete("/{app_name}/api/delete")
+async def ollama_delete_scoped(app_name: str, request: OllamaDeleteRequest) -> dict:
+    _ = app_name
+    return await ollama_delete(request)
+
+
+@ollama_router.post("/api/copy")
+async def ollama_copy(request: OllamaCopyRequest) -> JSONResponse:
+    """Explicitly unsupported safety mock."""
+    payload = build_copy_unsupported_payload(request.source, request.destination)
+    return JSONResponse(payload, status_code=501, media_type="application/json")
+
+
+@ollama_router.post("/{app_name}/api/copy")
+async def ollama_copy_scoped(app_name: str, request: OllamaCopyRequest) -> JSONResponse:
+    _ = app_name
+    return await ollama_copy(request)
+
+
+def _require_profile(name: str, capability: str | None = None):
+    profile = get_ollama_profile(name)
+    if profile is None:
+        raise HTTPException(status_code=404, detail=f"Model '{name}' is not configured")
+    if capability and profile.capability != capability:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Model '{name}' is registered for {profile.capability}, not {capability}",
+        )
+    return profile
+
+
+def _chat_request_from_ollama(request: OllamaChatRequest) -> ChatCompletionRequest:
+    messages: list[ChatMessage] = []
+    for msg in request.messages:
+        messages.append(_chat_message_from_ollama(msg))
+    if not messages:
+        raise HTTPException(status_code=400, detail="messages array cannot be empty")
+    return ChatCompletionRequest(
+        model=request.model,
+        messages=messages,
+        stream=False,
+        response_format=_map_ollama_format(request.format),
+    )
+
+
+def _generate_request_from_ollama(request: OllamaGenerateRequest) -> ChatCompletionRequest:
+    messages: list[ChatMessage] = []
+    if request.system:
+        messages.append(ChatMessage(role="system", content=request.system))
+
+    prompt_text = request.prompt or ""
+    if request.template and not request.raw:
+        prompt_text = f"[Template]\n{request.template}\n\n{prompt_text}"
+
+    content = _build_user_content(prompt_text, request.images or [])
+    messages.append(ChatMessage(role="user", content=content))
+
+    return ChatCompletionRequest(
+        model=request.model,
+        messages=messages,
+        stream=False,
+        response_format=_map_ollama_format(request.format),
+    )
+
+
+def _chat_message_from_ollama(message: OllamaChatMessage) -> ChatMessage:
+    content = _build_user_content(message.content or "", message.images or []) if message.images else (message.content or "")
+    return ChatMessage(role=message.role, content=content)
+
+
+def _build_user_content(text: str, images: list[str]) -> str | list[dict[str, Any]]:
+    if not images:
+        return text
+
+    parts: list[dict[str, Any]] = []
+    if text:
+        parts.append({"type": "text", "text": text})
+    for image in images:
+        url = image.strip()
+        if not url:
+            continue
+        if not (url.startswith("data:") or url.startswith("http://") or url.startswith("https://")):
+            url = f"data:image/png;base64,{url}"
+        parts.append({"type": "image_url", "image_url": {"url": url}})
+
+    return parts or text
+
+
+def _map_ollama_format(value: Any) -> Any:
+    if value in (None, "", False):
+        return None
+    if value == "json":
+        return {"type": "json_object"}
+    if isinstance(value, dict):
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "ollama_schema",
+                "schema": value,
+            },
+        }
+    return value
+
+
+def _ollama_chat_response(response, started_at: float, stream: bool) -> Response:
+    message_content = response.choices[0].message.content or ""
+    elapsed_ns = _elapsed_ns(started_at)
+    base_payload = {
+        "model": response.model,
+        "created_at": _created_at_iso(),
+        "message": {
+            "role": "assistant",
+            "content": message_content,
+        },
+        "done_reason": response.choices[0].finish_reason,
+        "done": True,
+        "total_duration": elapsed_ns,
+        "load_duration": 0,
+        "prompt_eval_count": response.usage.prompt_tokens,
+        "eval_count": response.usage.completion_tokens,
+    }
+    if not stream:
+        return JSONResponse(base_payload, media_type="application/json")
+
+    chunks = [
+        {
+            "model": response.model,
+            "created_at": base_payload["created_at"],
+            "message": {"role": "assistant", "content": message_content},
+            "done": False,
+        },
+        {
+            **base_payload,
+            "message": {"role": "assistant", "content": ""},
+        },
+    ]
+    return _ndjson_response(chunks)
+
+
+def _ollama_generate_response(response, started_at: float, stream: bool) -> Response:
+    text = response.choices[0].message.content or ""
+    elapsed_ns = _elapsed_ns(started_at)
+    base_payload = {
+        "model": response.model,
+        "created_at": _created_at_iso(),
+        "response": text,
+        "done_reason": response.choices[0].finish_reason,
+        "done": True,
+        "context": [],
+        "total_duration": elapsed_ns,
+        "load_duration": 0,
+        "prompt_eval_count": response.usage.prompt_tokens,
+        "eval_count": response.usage.completion_tokens,
+    }
+    if not stream:
+        return JSONResponse(base_payload, media_type="application/json")
+
+    chunks = [
+        {
+            "model": response.model,
+            "created_at": base_payload["created_at"],
+            "response": text,
+            "done": False,
+        },
+        {
+            **base_payload,
+            "response": "",
+        },
+    ]
+    return _ndjson_response(chunks)
+
+
+def _ndjson_response(items: Iterable[dict[str, Any]]) -> StreamingResponse:
+    def _iter_lines():
+        for item in items:
+            yield json.dumps(item, ensure_ascii=False) + "\n"
+
+    return StreamingResponse(_iter_lines(), media_type="application/x-ndjson")
+
+
+def _created_at_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _elapsed_ns(started_at: float) -> int:
+    return int((time.time() - started_at) * 1_000_000_000)

--- a/src/api/ollama_schemas.py
+++ b/src/api/ollama_schemas.py
@@ -1,0 +1,67 @@
+"""
+Minimal Ollama-compatible request schemas.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class OllamaChatMessage(BaseModel):
+    role: str = "user"
+    content: str = ""
+    images: Optional[list[str]] = None
+
+
+class OllamaChatRequest(BaseModel):
+    model: str
+    messages: list[OllamaChatMessage] = Field(default_factory=list)
+    stream: bool = False
+    format: Optional[Any] = None
+    keep_alive: Optional[Any] = None
+    options: Optional[dict[str, Any]] = None
+
+
+class OllamaGenerateRequest(BaseModel):
+    model: str
+    prompt: str = ""
+    system: Optional[str] = None
+    template: Optional[str] = None
+    stream: bool = False
+    raw: bool = False
+    format: Optional[Any] = None
+    keep_alive: Optional[Any] = None
+    options: Optional[dict[str, Any]] = None
+    context: Optional[list[int]] = None
+    images: Optional[list[str]] = None
+
+
+class OllamaEmbedRequest(BaseModel):
+    model: str
+    input: str | list[str]
+    truncate: Optional[bool] = None
+    options: Optional[dict[str, Any]] = None
+    keep_alive: Optional[Any] = None
+
+
+class OllamaShowRequest(BaseModel):
+    model: str
+    verbose: Optional[bool] = None
+
+
+class OllamaPullRequest(BaseModel):
+    model: str
+    stream: bool = False
+
+
+class OllamaDeleteRequest(BaseModel):
+    model: Optional[str] = None
+    name: Optional[str] = None
+
+
+class OllamaCopyRequest(BaseModel):
+    source: str
+    destination: str
+

--- a/src/api/openai_routes.py
+++ b/src/api/openai_routes.py
@@ -40,6 +40,12 @@ from src.api.openai_schemas import (
     ToolDefinition,
     UsageInfo,
 )
+from src.api.attachment_expander import (
+    AttachmentPageDescriptor,
+    build_attachment_context_note,
+    expand_attachments_for_chatgpt,
+)
+from src.api.browser_gate import browser_access_lock
 from src.chatgpt.client import ChatGPTClient
 from src.chatgpt.model_registry import (
     PUBLIC_BROWSER_MODEL_ID,
@@ -56,8 +62,6 @@ openai_router = APIRouter()
 # Global reference - set by server.py at startup
 _client: ChatGPTClient | None = None
 
-# Serialize all requests - single browser page, not thread-safe
-_lock = asyncio.Lock()
 _jobs_lock = asyncio.Lock()
 _jobs: dict[str, ChatCompletionJobResponse] = {}
 _job_app_keys: dict[str, str] = {}
@@ -627,7 +631,7 @@ async def _download_file(url_or_data: str | dict, download_dir: str = "/tmp/catg
                 mime = header.split(":")[1].split(";")[0]
             ext_map = {
                 "image/png": "png", "image/jpeg": "jpg", "image/webp": "webp",
-                "image/gif": "gif", "application/pdf": "pdf",
+                "image/gif": "gif", "image/tiff": "tiff", "application/pdf": "pdf",
                 "text/plain": "txt", "text/csv": "csv",
                 "application/json": "json",
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
@@ -648,7 +652,7 @@ async def _download_file(url_or_data: str | dict, download_dir: str = "/tmp/catg
         try:
             import urllib.request
             ext = "bin"
-            for e in ["jpg", "jpeg", "webp", "gif", "png", "pdf", "txt", "csv", "docx", "xlsx"]:
+            for e in ["jpg", "jpeg", "webp", "gif", "png", "tif", "tiff", "pdf", "txt", "csv", "docx", "xlsx"]:
                 if e in url.lower():
                     ext = e
                     break
@@ -863,6 +867,71 @@ def _build_response_format_system_prompt(response_format: Any) -> str | None:
         )
 
     return None
+
+
+def _page_extraction_mode(request: ChatCompletionRequest) -> str:
+    """Normalize the requested page-extraction mode string."""
+    options = getattr(request, "page_extraction", None)
+    mode = getattr(options, "mode", "") if options is not None else ""
+    return str(mode or "").strip().lower()
+
+
+def _build_page_extraction_response_format(
+    page_descriptors: list[AttachmentPageDescriptor],
+) -> dict[str, Any]:
+    """Build a strict JSON schema for page-by-page extraction output."""
+    if not page_descriptors:
+        raise ValueError("page_descriptors cannot be empty")
+
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "page_extraction",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "pages": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {
+                                "page_index": {"type": "integer"},
+                                "source_name": {"type": "string"},
+                                "page_number": {"type": "integer"},
+                                "text": {"type": "string"},
+                            },
+                            "required": ["page_index", "source_name", "page_number", "text"],
+                        },
+                    }
+                },
+                "required": ["pages"],
+            },
+        },
+    }
+
+
+def _build_page_extraction_note(page_descriptors: list[AttachmentPageDescriptor]) -> str:
+    """Build a compact prompt prefix describing the required page-map output."""
+    if not page_descriptors:
+        return ""
+
+    lines = [
+        "[Per-page extraction]",
+        f"- Return valid JSON only with a top-level `pages` array containing exactly {len(page_descriptors)} item(s).",
+        "- Preserve each `page_index`, `source_name`, and `page_number` exactly as listed below.",
+        "- Fill `text` with the extracted text for that page in reading order.",
+        "- If a page is blank or unreadable, keep the item and return an empty string for `text`.",
+        "- Keep the `pages` array in the same order as the numbered page map below.",
+        "- If an original document is also attached as a fallback, use it only to help read the listed page map. Do not add extra pages.",
+    ]
+    for descriptor in page_descriptors:
+        lines.append(
+            f"- page_index={descriptor.page_index}: '{descriptor.source_name}' page {descriptor.page_number}."
+        )
+    return "\n".join(lines) + "\n\n"
 
 
 def _extract_json_payload(text: str) -> Any | None:
@@ -1192,10 +1261,12 @@ def _infer_primary_array_count(payload: Any) -> int | None:
 
 
 def _structured_cardinality_mismatch(
-    messages: list[ChatMessage], response_text: str
+    messages: list[ChatMessage],
+    response_text: str,
+    expected_count: int | None = None,
 ) -> tuple[int, int] | None:
     """Return (expected, actual) if a clear structured cardinality mismatch exists."""
-    expected = _infer_expected_item_count(messages)
+    expected = expected_count if expected_count is not None else _infer_expected_item_count(messages)
     if expected is None:
         return None
 
@@ -1212,14 +1283,24 @@ def _structured_cardinality_mismatch(
     return None
 
 
-def _build_cardinality_retry_prompt(base_prompt: str, expected: int, actual: int) -> str:
+def _build_cardinality_retry_prompt(
+    base_prompt: str,
+    expected: int,
+    actual: int,
+    expectation_reason: str = "input line count",
+    correction_rule: str | None = None,
+) -> str:
     """Build a corrective retry prompt for structured cardinality mismatch."""
+    if not correction_rule:
+        correction_rule = (
+            "Return valid JSON only, with exactly one output item per non-empty input line, "
+            "preserving input order. Do not merge or drop lines."
+        )
     return (
         f"{base_prompt}\n\n"
         "Correction: The previous JSON had the wrong number of items.\n"
-        f"Input line count is {expected}, but output count was {actual}.\n"
-        "Return valid JSON only, with exactly one output item per non-empty input line, "
-        "preserving input order. Do not merge or drop lines."
+        f"Expected output count is {expected} based on {expectation_reason}, but output count was {actual}.\n"
+        f"{correction_rule}"
     )
 
 
@@ -1233,6 +1314,19 @@ def _validate_chat_request(request: ChatCompletionRequest) -> None:
 
     if not request.messages:
         raise HTTPException(status_code=400, detail="messages array cannot be empty")
+
+    page_extraction_mode = _page_extraction_mode(request)
+    if page_extraction_mode and page_extraction_mode != "structured":
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported page_extraction.mode. Supported modes: structured",
+        )
+
+    if page_extraction_mode and request.response_format:
+        raise HTTPException(
+            status_code=400,
+            detail="page_extraction.mode='structured' manages response_format automatically. Omit response_format.",
+        )
 
     if not is_supported_chat_model(request.model):
         supported = ", ".join(list_public_chat_models())
@@ -1289,7 +1383,7 @@ async def create_image(
 
     client = _get_client()
 
-    async with _lock:
+    async with browser_access_lock:
         start_time = time.time()
 
         # Build an image-generation prompt.
@@ -1428,7 +1522,7 @@ async def _execute_chat_completion(
     """Shared sync/async executor for chat completions."""
     client = _get_client()
 
-    async with _lock:
+    async with browser_access_lock:
         start_time = time.time()
         app_key = (app_key_override or "").strip()
         app_name = _display_app_name(app_key)
@@ -1470,6 +1564,60 @@ async def _execute_chat_completion(
                 await client.new_chat()
                 routing_action = "new-chat-for-app"
 
+        # -- Extract attachments from messages --------------
+        image_paths: list[str] = []
+        file_paths: list[str] = []
+        for msg in request.messages:
+            if msg.role == "user" and isinstance(msg.content, list):
+                image_urls = _extract_image_urls(msg.content)
+                for url in image_urls:
+                    local_path = await _download_file(url)
+                    if local_path:
+                        image_paths.append(local_path)
+
+                file_attachments = _extract_file_attachments(msg.content)
+                for fa in file_attachments:
+                    local_path = await _download_file(fa)
+                    if local_path:
+                        file_paths.append(local_path)
+
+        all_attachment_paths = image_paths + file_paths
+        if all_attachment_paths:
+            log.info(f"Extracted {len(image_paths)} image(s) and {len(file_paths)} file(s) from request")
+
+        expansion = expand_attachments_for_chatgpt(image_paths, file_paths)
+        image_paths = expansion.image_paths
+        file_paths = expansion.file_paths
+        page_extraction_mode = _page_extraction_mode(request)
+        page_extraction_expected_count: int | None = None
+        effective_response_format = request.response_format
+        prompt_prefixes: list[str] = []
+
+        if expansion.notes:
+            prompt_prefixes.append(build_attachment_context_note(expansion.notes))
+            log.info(
+                "Attachment expansion: rendered %d page image(s), upload set now has %d image(s) and %d file(s)",
+                expansion.total_rendered_pages,
+                len(image_paths),
+                len(file_paths),
+            )
+
+        if page_extraction_mode == "structured":
+            if not expansion.page_descriptors:
+                raise HTTPException(
+                    status_code=400,
+                    detail="page_extraction.mode='structured' requires at least one image or file attachment.",
+                )
+            page_extraction_expected_count = len(expansion.page_descriptors)
+            effective_response_format = _build_page_extraction_response_format(expansion.page_descriptors)
+            prompt_prefixes.append(_build_page_extraction_note(expansion.page_descriptors))
+            log.info(
+                "Per-page extraction mode enabled: %d logical page item(s)",
+                page_extraction_expected_count,
+            )
+
+        attachment_prefix = "".join(prefix for prefix in prompt_prefixes if prefix)
+
         # -- Build the prompt --------------------------------
         messages = list(request.messages)
 
@@ -1480,7 +1628,7 @@ async def _execute_chat_completion(
             messages.insert(0, ChatMessage(role="system", content=tool_system))
 
         # If structured output is requested, force strict JSON response
-        response_format_system = _build_response_format_system_prompt(request.response_format)
+        response_format_system = _build_response_format_system_prompt(effective_response_format)
         if response_format_system and not _has_equivalent_response_instruction(messages, response_format_system):
             messages.insert(0, ChatMessage(role="system", content=response_format_system))
 
@@ -1533,7 +1681,7 @@ async def _execute_chat_completion(
                         prefix, tail = detected_prefix
                         candidate_user_contract_id = _user_contract_hash(system_texts, prefix)
                         known_user = _thread_user_contracts.get(current_thread_id)
-                        if known_user and known_user[1] == candidate_user_contract_id and request.response_format:
+                        if known_user and known_user[1] == candidate_user_contract_id and effective_response_format:
                             prompt = _build_user_contract_reminder_prompt(
                                 tail,
                                 contract_id,
@@ -1575,6 +1723,10 @@ async def _execute_chat_completion(
                 user_contract_id[:12] if user_contract_id else "unknown",
             )
 
+        if attachment_prefix:
+            prompt = f"{attachment_prefix}{prompt}" if prompt else attachment_prefix.strip()
+            full_prompt = f"{attachment_prefix}{full_prompt}" if full_prompt else attachment_prefix.strip()
+
         cache_key = _cache_key_for_request_with_app(request, app_key)
         now = time.time()
         async with _cache_lock:
@@ -1583,27 +1735,6 @@ async def _execute_chat_completion(
             if cached_entry and now - cached_entry[0] <= _CACHE_TTL_SECONDS:
                 log.info("Response cache hit: returning cached completion")
                 return _clone_cached_response(cached_entry[1])
-
-        # -- Extract attachments from messages --------------
-        image_paths: list[str] = []
-        file_paths: list[str] = []
-        for msg in request.messages:
-            if msg.role == "user" and isinstance(msg.content, list):
-                image_urls = _extract_image_urls(msg.content)
-                for url in image_urls:
-                    local_path = await _download_file(url)
-                    if local_path:
-                        image_paths.append(local_path)
-
-                file_attachments = _extract_file_attachments(msg.content)
-                for fa in file_attachments:
-                    local_path = await _download_file(fa)
-                    if local_path:
-                        file_paths.append(local_path)
-
-        all_attachment_paths = image_paths + file_paths
-        if all_attachment_paths:
-            log.info(f"Extracted {len(image_paths)} image(s) and {len(file_paths)} file(s) from request")
 
         # -- Send to ChatGPT --------------------------------
         try:
@@ -1644,7 +1775,7 @@ async def _execute_chat_completion(
         response_text = result.message
         elapsed_ms = int((time.time() - start_time) * 1000)
 
-        if (used_thread_contract or used_user_contract) and request.response_format and _extract_json_payload(response_text) is None:
+        if (used_thread_contract or used_user_contract) and effective_response_format and _extract_json_payload(response_text) is None:
             mode_name = "user-prefix contract" if used_user_contract else "thread contract"
             log.warning("%s mode produced non-JSON content. Retrying once with full prompt.", mode_name.capitalize())
             try:
@@ -1684,9 +1815,13 @@ async def _execute_chat_completion(
         tool_calls = None
         finish_reason = "stop"
 
-        if request.response_format and response_text:
-            response_text = _normalize_structured_content(response_text, request.response_format)
-            mismatch = _structured_cardinality_mismatch(request.messages, response_text)
+        if effective_response_format and response_text:
+            response_text = _normalize_structured_content(response_text, effective_response_format)
+            mismatch = _structured_cardinality_mismatch(
+                request.messages,
+                response_text,
+                expected_count=page_extraction_expected_count,
+            )
             if mismatch:
                 expected, actual = mismatch
                 log.warning(
@@ -1694,7 +1829,19 @@ async def _execute_chat_completion(
                     expected,
                     actual,
                 )
-                retry_prompt = _build_cardinality_retry_prompt(prompt, expected, actual)
+                retry_prompt = _build_cardinality_retry_prompt(
+                    prompt,
+                    expected,
+                    actual,
+                    expectation_reason="the numbered page map" if page_extraction_expected_count is not None else "input line count",
+                    correction_rule=(
+                        "Return valid JSON only, with exactly one output item per numbered page-map entry, "
+                        "preserving `page_index`, `source_name`, and `page_number` exactly and keeping the same order. "
+                        "Do not merge, drop, or add pages."
+                    )
+                    if page_extraction_expected_count is not None
+                    else None,
+                )
                 try:
                     retry_result = await client.send_message(
                         retry_prompt,
@@ -1703,8 +1850,12 @@ async def _execute_chat_completion(
                         model=request.model,
                     )
                     retry_text = retry_result.message
-                    retry_text = _normalize_structured_content(retry_text, request.response_format)
-                    retry_mismatch = _structured_cardinality_mismatch(request.messages, retry_text)
+                    retry_text = _normalize_structured_content(retry_text, effective_response_format)
+                    retry_mismatch = _structured_cardinality_mismatch(
+                        request.messages,
+                        retry_text,
+                        expected_count=page_extraction_expected_count,
+                    )
                     if not retry_mismatch:
                         response_text = retry_text
                         elapsed_ms = int((time.time() - start_time) * 1000)

--- a/src/api/openai_schemas.py
+++ b/src/api/openai_schemas.py
@@ -68,6 +68,11 @@ class ChatMessage(BaseModel):
 # ── Request ─────────────────────────────────────────────────────
 
 
+class PageExtractionOptions(BaseModel):
+    """CatGPT extension for structured page-by-page document extraction."""
+    mode: str = "structured"
+
+
 class ChatCompletionRequest(BaseModel):
     """OpenAI-compatible chat completion request body."""
     model: str = "catgpt-browser"
@@ -86,6 +91,8 @@ class ChatCompletionRequest(BaseModel):
     # CatGPT extension: explicit thread targeting for app-level isolation.
     thread_id: Optional[str] = None
     response_format: Optional[Any] = None
+    # CatGPT extension: force structured page-by-page extraction for attachments.
+    page_extraction: Optional[PageExtractionOptions] = None
 
 
 # ── Response ────────────────────────────────────────────────────

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -11,10 +11,9 @@ Endpoints:
 
 from __future__ import annotations
 
-import asyncio
-
 from fastapi import APIRouter, HTTPException
 
+from src.api.browser_gate import browser_access_lock
 from src.api.schemas import (
     ChatRequest,
     ChatResponse,
@@ -31,9 +30,6 @@ from src.log import setup_logging
 log = setup_logging("api_routes")
 
 router = APIRouter()
-
-# Serialize browser access — single page, not thread-safe
-_lock = asyncio.Lock()
 
 # Global reference — set by the server on startup
 _client: ChatGPTClient | None = None
@@ -96,7 +92,7 @@ async def chat(req: ChatRequest) -> ChatResponse:
     client = _get_client()
     log.info(f"POST /chat — {len(req.message)} chars")
 
-    async with _lock:
+    async with browser_access_lock:
         try:
             _validate_model(req.model)
             result = await client.send_message(req.message, model=req.model)
@@ -112,7 +108,7 @@ async def chat_in_thread(thread_id: str, req: ChatRequest) -> ChatResponse:
     client = _get_client()
     log.info(f"POST /thread/{thread_id}/chat — {len(req.message)} chars")
 
-    async with _lock:
+    async with browser_access_lock:
         try:
             _validate_model(req.model)
             # Navigate to the thread if not already there
@@ -133,7 +129,7 @@ async def new_thread(req: ChatRequest) -> ChatResponse:
     client = _get_client()
     log.info(f"POST /thread/new — {len(req.message)} chars")
 
-    async with _lock:
+    async with browser_access_lock:
         try:
             _validate_model(req.model)
             await client.new_chat()
@@ -153,7 +149,7 @@ async def list_threads() -> ThreadListResponse:
     client = _get_client()
     log.info("GET /threads")
 
-    async with _lock:
+    async with browser_access_lock:
         try:
             raw_threads = await client.list_threads()
             threads = [
@@ -174,8 +170,9 @@ async def status() -> StatusResponse:
     """Health check — returns login status and current thread."""
     try:
         client = _get_client()
-        logged_in = await _browser.is_logged_in()
-        tid = client._extract_thread_id()
-        return StatusResponse(status="ok", logged_in=logged_in, current_thread=tid)
+        async with browser_access_lock:
+            logged_in = await _browser.is_logged_in()
+            tid = client._extract_thread_id()
+            return StatusResponse(status="ok", logged_in=logged_in, current_thread=tid)
     except Exception:
         return StatusResponse(status="ok", logged_in=False, current_thread="")

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -26,6 +26,7 @@ from src.browser.manager import BrowserManager
 from src.browser.auto_login import ensure_logged_in
 from src.chatgpt.client import ChatGPTClient
 from src.config import Config
+from src.api.ollama_routes import ollama_router
 from src.api.routes import router, set_client
 from src.api.openai_routes import openai_router, set_openai_client
 from src.log import setup_logging
@@ -150,6 +151,12 @@ async def lifespan(app: FastAPI):
         ("POST", f"{host}/{{app_name}}/v1/images/generations", "App-scoped image generation"),
         ("GET ", f"{host}/v1/models", "List models"),
         ("GET ", f"{host}/{{app_name}}/v1/models", "App-scoped models"),
+        ("POST", f"{host}/api/chat", "Ollama-compatible chat"),
+        ("POST", f"{host}/api/generate", "Ollama-compatible generation"),
+        ("POST", f"{host}/api/embed", "Ollama-compatible embeddings"),
+        ("GET ", f"{host}/api/tags", "Ollama model tags"),
+        ("POST", f"{host}/api/show", "Ollama model metadata"),
+        ("GET ", f"{host}/api/ps", "Ollama active models"),
         ("POST", f"{host}/chat", "Native chat"),
         ("POST", f"{host}/thread/new", "New thread"),
         ("GET ", f"{host}/threads", "List threads"),
@@ -271,6 +278,7 @@ app.add_middleware(
 
 app.include_router(router)
 app.include_router(openai_router)
+app.include_router(ollama_router)
 
 
 @app.get("/healthz", include_in_schema=False)

--- a/src/config.py
+++ b/src/config.py
@@ -32,6 +32,12 @@ class Config:
         "gpt-5.5=GPT-5.5,gpt-5.5-pro=GPT-5.5 pro,gpt-5.4=GPT-5.4,gpt-5.4-pro=GPT-5.4 pro,gpt-5.4-mini=GPT-5.4 mini,gpt-5.4-nano=GPT-5.4 nano,gpt-5-mini=GPT-5 mini,gpt-5-nano=GPT-5 nano,gpt-5=GPT-5,gpt-5.3=GPT-5.3,o3=o3,o4-mini=o4-mini,gpt-4.5=GPT-4.5,gpt-4.1=GPT-4.1,gpt-4.1-mini=GPT-4.1 mini,gpt-4o=GPT-4o",
     )
     CHATGPT_MODEL_SWITCH_TIMEOUT: int = int(os.getenv("CHATGPT_MODEL_SWITCH_TIMEOUT", "10000"))
+    ATTACHMENT_EXPAND_MULTIPAGE: bool = os.getenv("ATTACHMENT_EXPAND_MULTIPAGE", "true").lower() == "true"
+    ATTACHMENT_MAX_PAGES: int = int(os.getenv("ATTACHMENT_MAX_PAGES", "24"))
+    ATTACHMENT_RENDER_DPI: int = int(os.getenv("ATTACHMENT_RENDER_DPI", "144"))
+    OLLAMA_EMBEDDING_MODELS: str = os.getenv("OLLAMA_EMBEDDING_MODELS", "nomic-embed-text")
+    OLLAMA_EMBEDDING_DIMENSIONS: int = int(os.getenv("OLLAMA_EMBEDDING_DIMENSIONS", "768"))
+    OLLAMA_ACTIVE_MODEL_TTL_SECONDS: int = int(os.getenv("OLLAMA_ACTIVE_MODEL_TTL_SECONDS", "900"))
 
     # Timeouts (ms)
     RESPONSE_TIMEOUT: int = int(os.getenv("RESPONSE_TIMEOUT", "120000"))

--- a/tests/test_attachment_expander.py
+++ b/tests/test_attachment_expander.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import unittest
+import uuid
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+from src.api.attachment_expander import (
+    build_attachment_context_note,
+    expand_attachments_for_chatgpt,
+)
+
+try:
+    import fitz  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency in test env
+    fitz = None
+
+try:
+    from PIL import Image  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency in test env
+    Image = None
+
+
+@unittest.skipUnless(fitz is not None and Image is not None, "attachment expansion dependencies are unavailable")
+class AttachmentExpanderTests(unittest.TestCase):
+    def test_expand_pdf_renders_all_pages(self) -> None:
+        tmpdir = self._make_scratch_dir()
+        try:
+            pdf_path = tmpdir / "sample.pdf"
+            doc = fitz.open()
+            for page_number in range(3):
+                page = doc.new_page()
+                page.insert_text((72, 72), f"Page {page_number + 1}")
+            doc.save(pdf_path)
+            doc.close()
+
+            result = expand_attachments_for_chatgpt([], [str(pdf_path)])
+
+            self.assertEqual(len(result.image_paths), 3)
+            self.assertEqual(result.file_paths, [])
+            self.assertEqual(result.total_rendered_pages, 3)
+            self.assertEqual([page.page_number for page in result.page_descriptors], [1, 2, 3])
+            self.assertEqual([page.page_index for page in result.page_descriptors], [1, 2, 3])
+            self.assertTrue(any("sample.pdf" in note for note in result.notes))
+            for image_path in result.image_paths:
+                self.assertTrue(Path(image_path).exists())
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_expand_multiframe_image_renders_all_frames(self) -> None:
+        tmpdir = self._make_scratch_dir()
+        try:
+            image_path = tmpdir / "frames.tiff"
+            frames = [
+                Image.new("RGB", (20, 20), color)
+                for color in ("red", "green", "blue")
+            ]
+            frames[0].save(image_path, save_all=True, append_images=frames[1:], format="TIFF")
+
+            result = expand_attachments_for_chatgpt([str(image_path)], [])
+
+            self.assertEqual(len(result.image_paths), 3)
+            self.assertEqual(result.file_paths, [])
+            self.assertEqual(result.total_rendered_pages, 3)
+            self.assertEqual([page.page_number for page in result.page_descriptors], [1, 2, 3])
+            self.assertTrue(any("frames.tiff" in note for note in result.notes))
+            for page_path in result.image_paths:
+                self.assertTrue(Path(page_path).exists())
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_page_limit_is_applied(self) -> None:
+        tmpdir = self._make_scratch_dir()
+        try:
+            with patch(
+                "src.api.attachment_expander.Config.ATTACHMENT_MAX_PAGES",
+                2,
+            ):
+                pdf_path = tmpdir / "limited.pdf"
+                doc = fitz.open()
+                for page_number in range(4):
+                    page = doc.new_page()
+                    page.insert_text((72, 72), f"Page {page_number + 1}")
+                doc.save(pdf_path)
+                doc.close()
+
+                result = expand_attachments_for_chatgpt([], [str(pdf_path)])
+
+                self.assertEqual(len(result.image_paths), 2)
+                self.assertTrue(any("Limited to the first 2 of 4 pages." in note for note in result.notes))
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_attachment_context_note_mentions_ordering(self) -> None:
+        note = build_attachment_context_note(["Expanded 'doc.pdf' into 3 ordered page image(s)."])
+        self.assertIn("[Attachment processing]", note)
+        self.assertIn("ordered pages", note)
+
+    def test_passthrough_file_still_gets_page_descriptor(self) -> None:
+        tmpdir = self._make_scratch_dir()
+        try:
+            file_path = tmpdir / "notes.txt"
+            file_path.write_text("hello", encoding="utf-8")
+
+            result = expand_attachments_for_chatgpt([], [str(file_path)])
+
+            self.assertEqual(result.image_paths, [])
+            self.assertEqual(result.file_paths, [str(file_path)])
+            self.assertEqual(len(result.page_descriptors), 1)
+            self.assertEqual(result.page_descriptors[0].source_name, "notes.txt")
+            self.assertEqual(result.page_descriptors[0].page_number, 1)
+            self.assertEqual(result.page_descriptors[0].page_index, 1)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def _make_scratch_dir(self) -> Path:
+        root = Path.cwd() / "test_scratch"
+        root.mkdir(parents=True, exist_ok=True)
+        path = root / f"attachment-expander-{uuid.uuid4().hex}"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ollama_routes.py
+++ b/tests/test_ollama_routes.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Provide minimal browser stubs before importing API modules.
+if "patchright" not in sys.modules:
+    patchright_mod = types.ModuleType("patchright")
+    async_api_mod = types.ModuleType("patchright.async_api")
+    async_api_mod.Page = object
+    async_api_mod.BrowserContext = object
+    async_api_mod.Playwright = object
+    async_api_mod.Frame = object
+    async_api_mod.Request = object
+    async_api_mod.Response = object
+
+    async def _fake_async_playwright():
+        return None
+
+    async_api_mod.async_playwright = _fake_async_playwright
+    sys.modules["patchright"] = patchright_mod
+    sys.modules["patchright.async_api"] = async_api_mod
+
+if "playwright_stealth" not in sys.modules:
+    playwright_stealth_mod = types.ModuleType("playwright_stealth")
+
+    class _FakeStealth:
+        script_payload = ""
+
+    playwright_stealth_mod.Stealth = _FakeStealth
+    sys.modules["playwright_stealth"] = playwright_stealth_mod
+
+from src.api.ollama_registry import build_show_payload, generate_embeddings, get_ollama_profile, list_ollama_profiles
+from src.api.ollama_routes import ollama_router
+from src.api.openai_schemas import ChatCompletionResponse, Choice, ChoiceMessage, UsageInfo
+
+
+def _make_stub_chat_response(model: str = "catgpt-browser", text: str = "hello from catgpt") -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        model=model,
+        choices=[
+            Choice(
+                index=0,
+                message=ChoiceMessage(role="assistant", content=text),
+                finish_reason="stop",
+            )
+        ],
+        usage=UsageInfo(prompt_tokens=10, completion_tokens=4, total_tokens=14),
+    )
+
+
+class OllamaRegistryTests(unittest.TestCase):
+    def test_profiles_include_chat_and_embedding_models(self) -> None:
+        with patch("src.api.ollama_registry.Config.OLLAMA_EMBEDDING_MODELS", "nomic-embed-text,mxbai-embed-large"):
+            names = [profile.name for profile in list_ollama_profiles()]
+        self.assertIn("catgpt-browser", names)
+        self.assertIn("nomic-embed-text", names)
+        self.assertIn("mxbai-embed-large", names)
+
+    def test_show_payload_is_deterministic(self) -> None:
+        profile = get_ollama_profile("catgpt-browser")
+        assert profile is not None
+        payload = build_show_payload(profile)
+        self.assertEqual(payload["digest"], profile.digest)
+        self.assertIn("FROM catgpt-browser", payload["modelfile"])
+
+    def test_embeddings_are_deterministic(self) -> None:
+        first = generate_embeddings("nomic-embed-text", ["hello world"])
+        second = generate_embeddings("nomic-embed-text", ["hello world"])
+        self.assertEqual(first["embeddings"], second["embeddings"])
+        self.assertEqual(len(first["embeddings"][0]), 768)
+
+
+class OllamaRouteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        app = FastAPI()
+        app.include_router(ollama_router)
+        self.client = TestClient(app)
+
+    def test_tags_endpoint_returns_models(self) -> None:
+        response = self.client.get("/api/tags")
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIn("models", payload)
+        self.assertTrue(any(item["name"] == "catgpt-browser" for item in payload["models"]))
+
+    def test_embed_endpoint_returns_embedding_array(self) -> None:
+        response = self.client.post("/api/embed", json={"model": "nomic-embed-text", "input": "hello"})
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["model"], "nomic-embed-text")
+        self.assertEqual(len(payload["embeddings"]), 1)
+        self.assertEqual(len(payload["embeddings"][0]), 768)
+
+    def test_chat_stream_endpoint_returns_ndjson(self) -> None:
+        async def _fake_execute(request, app_key_override=""):
+            _ = request, app_key_override
+            return _make_stub_chat_response(text="streamed hello")
+
+        with patch("src.api.ollama_routes._execute_chat_completion", side_effect=_fake_execute), patch(
+            "src.api.ollama_routes._resolve_app_key",
+            return_value="",
+        ):
+            response = self.client.post(
+                "/api/chat",
+                json={
+                    "model": "catgpt-browser",
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"].split(";")[0], "application/x-ndjson")
+        lines = [line for line in response.text.splitlines() if line.strip()]
+        self.assertEqual(len(lines), 2)
+        self.assertIn('"done": false', lines[0])
+        self.assertIn('"done": true', lines[1])
+
+    def test_generate_scoped_endpoint_maps_to_chat_backend(self) -> None:
+        async def _fake_execute(request, app_key_override=""):
+            self.assertEqual(app_key_override, "endpoint:demo")
+            self.assertEqual(request.messages[0].role, "user")
+            return _make_stub_chat_response(model=request.model, text="generated text")
+
+        with patch("src.api.ollama_routes._execute_chat_completion", side_effect=_fake_execute), patch(
+            "src.api.ollama_routes._resolve_app_key",
+            return_value="endpoint:demo",
+        ):
+            response = self.client.post(
+                "/demo/api/generate",
+                json={"model": "catgpt-browser", "prompt": "Write one sentence."},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["response"], "generated text")
+        self.assertEqual(payload["model"], "catgpt-browser")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openai_routes_helpers.py
+++ b/tests/test_openai_routes_helpers.py
@@ -36,15 +36,22 @@ if "playwright_stealth" not in sys.modules:
     sys.modules["playwright_stealth"] = playwright_stealth_mod
 
 from src.api.openai_routes import (
+    _build_page_extraction_note,
+    _build_page_extraction_response_format,
     _detect_user_prefix_contract,
     _display_app_name,
     _derive_app_key,
     _infer_expected_item_count,
     _looks_like_instruction_prefix,
     _merge_header_rows_in_array,
+    _structured_cardinality_mismatch,
     _should_use_line_cardinality_fallback,
     _validate_chat_request,
 )
+from src.api.browser_gate import browser_access_lock
+from src.api import routes as native_routes
+from src.api import openai_routes as openai_routes_module
+from src.api.attachment_expander import AttachmentPageDescriptor
 from src.api.openai_schemas import ChatCompletionRequest, ChatMessage
 
 
@@ -67,6 +74,10 @@ def _make_request(headers: dict[str, str] | None = None, client_host: str = "127
 
 
 class OpenAIRoutesHelpersTests(unittest.TestCase):
+    def test_route_families_share_browser_access_lock(self) -> None:
+        self.assertIs(native_routes.browser_access_lock, browser_access_lock)
+        self.assertIs(openai_routes_module.browser_access_lock, browser_access_lock)
+
     def test_derive_app_key_prefers_user(self) -> None:
         req = ChatCompletionRequest(
             messages=[ChatMessage(role="user", content="hello")],
@@ -202,6 +213,55 @@ class OpenAIRoutesHelpersTests(unittest.TestCase):
             _validate_chat_request(req)
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertIn("Unsupported model", ctx.exception.detail)
+
+    def test_validate_chat_request_rejects_unknown_page_extraction_mode(self) -> None:
+        req = ChatCompletionRequest(
+            messages=[ChatMessage(role="user", content="hello")],
+            page_extraction={"mode": "table"},
+        )
+        with self.assertRaises(HTTPException) as ctx:
+            _validate_chat_request(req)
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("Unsupported page_extraction.mode", ctx.exception.detail)
+
+    def test_validate_chat_request_rejects_page_extraction_with_response_format(self) -> None:
+        req = ChatCompletionRequest(
+            messages=[ChatMessage(role="user", content="hello")],
+            response_format="json_object",
+            page_extraction={"mode": "structured"},
+        )
+        with self.assertRaises(HTTPException) as ctx:
+            _validate_chat_request(req)
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("manages response_format automatically", ctx.exception.detail)
+
+    def test_build_page_extraction_note_lists_pages(self) -> None:
+        note = _build_page_extraction_note(
+            [
+                AttachmentPageDescriptor(source_name="contract.pdf", page_number=1, page_index=1, source_kind="pdf"),
+                AttachmentPageDescriptor(source_name="contract.pdf", page_number=2, page_index=2, source_kind="pdf"),
+            ]
+        )
+        self.assertIn("[Per-page extraction]", note)
+        self.assertIn("exactly 2 item(s)", note)
+        self.assertIn("page_index=1", note)
+        self.assertIn("page 2", note)
+
+    def test_build_page_extraction_response_format_requires_pages_array(self) -> None:
+        response_format = _build_page_extraction_response_format(
+            [AttachmentPageDescriptor(source_name="doc.pdf", page_number=1, page_index=1, source_kind="pdf")]
+        )
+        self.assertEqual(response_format["type"], "json_schema")
+        schema = response_format["json_schema"]["schema"]
+        self.assertIn("pages", schema["properties"])
+        self.assertEqual(schema["required"], ["pages"])
+
+    def test_structured_cardinality_mismatch_uses_explicit_expected_count(self) -> None:
+        messages = [ChatMessage(role="user", content="single page")]
+        response_text = '{"pages":[{"page_index":1,"source_name":"a.pdf","page_number":1,"text":"a"}]}'
+        self.assertIsNone(_structured_cardinality_mismatch(messages, response_text, expected_count=1))
+        mismatch = _structured_cardinality_mismatch(messages, '{"pages":[]}', expected_count=1)
+        self.assertEqual(mismatch, (1, 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add Ollama-compatible API routes, schemas, and registry helpers on top of the existing browser backend
- add attachment expansion with multi-page PDF and multi-frame image handling, plus structured per-page OCR output support
- document the parallel browser execution investigation and keep that work at the investigation/safety-hardening stage
- centralize browser access locking across route families to avoid cross-route races on the shared ChatGPT page

## Testing
- .\\.venv\\Scripts\\python.exe -m unittest tests.test_openai_routes_helpers tests.test_ollama_routes tests.test_attachment_expander tests.test_model_registry