### PR TITLE
Fix response copy button selection

### DIFF
--- a/docs/CHROME_PLAYWRIGHT_RUNBOOK.md
+++ b/docs/CHROME_PLAYWRIGHT_RUNBOOK.md
@@ -1,0 +1,80 @@
+# Chrome and Playwright Runbook
+
+This file records the manual browser workflow used while testing CatGPT issues.
+CatGPT stores login state in `browser_data/`; only one Chrome/Chromium process can
+use that profile at a time.
+
+## Open Chrome for Login
+
+From the repo root on Windows PowerShell:
+
+```powershell
+$profile = Join-Path (Get-Location) 'browser_data'
+New-Item -ItemType Directory -Force -Path $profile | Out-Null
+$chrome = 'C:\Program Files\Google\Chrome\Application\chrome.exe'
+$args = @("--user-data-dir=$profile", "--no-first-run", "--no-default-browser-check", "https://chatgpt.com")
+Start-Process -FilePath $chrome -ArgumentList $args
+Write-Output "Opened Chrome with profile: $profile"
+```
+
+Sign in, wait until the ChatGPT composer is visible, then close that Chrome
+window before running Playwright/Patchright tests. If Chrome stays open,
+Playwright will fail with a profile-lock error like:
+
+```text
+Opening in existing browser session. This usually means that the profile is already in use.
+```
+
+## Launch Playwright with Saved Login
+
+Patchright may not have its bundled browser installed locally. When that happens,
+launch installed Chrome explicitly:
+
+```python
+from patchright.async_api import async_playwright
+
+pw = await async_playwright().start()
+context = await pw.chromium.launch_persistent_context(
+    user_data_dir="browser_data",
+    executable_path=r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+    headless=False,
+    slow_mo=50,
+    viewport={"width": 1280, "height": 720},
+    args=[
+        "--disable-blink-features=AutomationControlled",
+        "--no-first-run",
+        "--no-default-browser-check",
+    ],
+)
+page = context.pages[0] if context.pages else await context.new_page()
+await page.goto("https://chatgpt.com", wait_until="domcontentloaded")
+```
+
+Always close the context when done:
+
+```python
+await context.close()
+await pw.stop()
+```
+
+## Docker and noVNC Login
+
+In Docker, use the browser exposed through noVNC:
+
+```text
+http://localhost:6080/vnc.html
+```
+
+The API process is non-interactive under supervisor, so it should not wait for
+terminal input. If login is required, sign in through noVNC and then check:
+
+```bash
+curl http://localhost:8000/status
+```
+
+## Testing Response Copy Selection
+
+For issue #42, use a prompt that forces an early code block plus a final
+sentinel. The extracted response should include both the code marker and the
+final sentinel. If only the code marker is present, CatGPT clicked an inline
+code-block copy button instead of the response-level copy button.

--- a/src/chatgpt/detector.py
+++ b/src/chatgpt/detector.py
@@ -56,6 +56,38 @@ _CONVERSATION_SNAPSHOT_JS = r"""
         '[role="button"][aria-label*="copy" i]'
     ].join(",");
 
+    const preferredTurnCopySelector = [
+        'button[data-testid="copy-turn-action-button"]',
+        'button[aria-label="Copy response" i]',
+        'button[aria-label="Copy message" i]',
+        '[role="button"][aria-label="Copy response" i]',
+        '[role="button"][aria-label="Copy message" i]'
+    ].join(",");
+
+    const isCodeCopyButton = (el) => {
+        if (!el) return false;
+        const label = [
+            el.getAttribute("aria-label") || "",
+            el.getAttribute("data-testid") || "",
+            textOf(el).slice(0, 80)
+        ].join(" ").toLowerCase();
+        return Boolean(el.closest("pre, code, .code-block, [data-testid*='code' i]")) ||
+            label.includes("copy code");
+    };
+
+    const findTurnCopyButton = (root) => {
+        const preferred = Array.from(root.querySelectorAll(preferredTurnCopySelector))
+            .filter((button) => !isCodeCopyButton(button));
+        const visiblePreferred = preferred.find(isVisible);
+        if (visiblePreferred) return visiblePreferred;
+        if (preferred.length) return preferred[preferred.length - 1];
+
+        const fallback = Array.from(root.querySelectorAll(copySelector))
+            .filter((button) => !isCodeCopyButton(button));
+        const visibleFallback = fallback.filter(isVisible);
+        return visibleFallback[visibleFallback.length - 1] || fallback[fallback.length - 1] || null;
+    };
+
     const stopSelector = [
         'button[data-testid="stop-button"]',
         'button[aria-label="Stop answering"]',
@@ -200,7 +232,7 @@ _CONVERSATION_SNAPSHOT_JS = r"""
         const rect = item.rect;
         const text = bestTextFor(root, role);
         const hasImage = hasGeneratedImage(root);
-        const hasCopyButton = Boolean(root.querySelector(copySelector));
+        const hasCopyButton = Boolean(findTurnCopyButton(root));
         if (role === "assistant" && !text && !hasImage && !hasCopyButton) continue;
         if (role === "user" && !text) continue;
 
@@ -293,6 +325,13 @@ _CLICK_LATEST_COPY_BUTTON_JS = r"""
         'button[aria-label*="copy" i]',
         '[role="button"][aria-label*="copy" i]'
     ].join(",");
+    const preferredTurnCopySelector = [
+        'button[data-testid="copy-turn-action-button"]',
+        'button[aria-label="Copy response" i]',
+        'button[aria-label="Copy message" i]',
+        '[role="button"][aria-label="Copy response" i]',
+        '[role="button"][aria-label="Copy message" i]'
+    ].join(",");
     const hasGeneratedImage = (root) => {
         if (!root) return false;
         if (root.querySelector('img[alt="Generated image"], img[alt*="generated" i], div[id^="image-"], div[class*="imagegen-image"]')) return true;
@@ -303,6 +342,28 @@ _CLICK_LATEST_COPY_BUTTON_JS = r"""
             if ((w > 180 || h > 180) && (src.includes("backend-api/estuary") || src.includes("files.oaiusercontent.com") || src.startsWith("blob:") || src.startsWith("data:image/"))) return true;
         }
         return false;
+    };
+    const isCodeCopyButton = (el) => {
+        if (!el) return false;
+        const label = [
+            el.getAttribute("aria-label") || "",
+            el.getAttribute("data-testid") || "",
+            textOf(el).slice(0, 80)
+        ].join(" ").toLowerCase();
+        return Boolean(el.closest("pre, code, .code-block, [data-testid*='code' i]")) ||
+            label.includes("copy code");
+    };
+    const findTurnCopyButton = (root) => {
+        const preferred = Array.from(root.querySelectorAll(preferredTurnCopySelector))
+            .filter((button) => !isCodeCopyButton(button));
+        const visiblePreferred = preferred.find(isVisible);
+        if (visiblePreferred) return visiblePreferred;
+        if (preferred.length) return preferred[preferred.length - 1];
+
+        const fallback = Array.from(root.querySelectorAll(copySelector))
+            .filter((button) => !isCodeCopyButton(button));
+        const visibleFallback = fallback.filter(isVisible);
+        return visibleFallback[visibleFallback.length - 1] || fallback[fallback.length - 1] || null;
     };
     const roleOf = (root) => {
         const ownRole = root.getAttribute("data-message-author-role") || root.getAttribute("data-turn") || "";
@@ -401,14 +462,14 @@ _CLICK_LATEST_COPY_BUTTON_JS = r"""
         return { clicked: false, reason: "stale-turn", signature: latest.signature };
     }
 
-    let btn = Array.from(latest.root.querySelectorAll(copySelector)).find(isVisible) ||
-        latest.root.querySelector(copySelector);
+    let btn = findTurnCopyButton(latest.root);
     if (!btn) {
         const rootRect = latest.root.getBoundingClientRect();
         const nearby = Array.from(document.querySelectorAll(copySelector))
             .filter((candidate) => {
                 const rect = candidate.getBoundingClientRect();
-                return rect.top >= rootRect.top - 10 &&
+                return !isCodeCopyButton(candidate) &&
+                    rect.top >= rootRect.top - 10 &&
                     rect.top <= rootRect.bottom + 120 &&
                     rect.left >= rootRect.left - 60 &&
                     rect.left <= rootRect.right + 60;

--- a/tests/test_detector_helpers.py
+++ b/tests/test_detector_helpers.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import sys
 import types
 import unittest
+import importlib.util
+from pathlib import Path
 
 
-if "patchright" not in sys.modules:
+if "patchright" not in sys.modules and importlib.util.find_spec("patchright.async_api") is None:
     patchright_mod = types.ModuleType("patchright")
     async_api_mod = types.ModuleType("patchright.async_api")
     async_api_mod.Page = object
@@ -15,7 +17,7 @@ if "patchright" not in sys.modules:
     async_api_mod.Request = object
     async_api_mod.Response = object
 
-    async def _fake_async_playwright():
+    def _fake_async_playwright():
         return None
 
     async_api_mod.async_playwright = _fake_async_playwright
@@ -32,7 +34,13 @@ if "playwright_stealth" not in sys.modules:
     sys.modules["playwright_stealth"] = playwright_stealth_mod
 
 
-from src.chatgpt.detector import is_incomplete_response_text, normalize_assistant_text
+from patchright.async_api import async_playwright
+
+from src.chatgpt.detector import (
+    _CLICK_LATEST_COPY_BUTTON_JS,
+    is_incomplete_response_text,
+    normalize_assistant_text,
+)
 
 
 class DetectorHelperTests(unittest.TestCase):
@@ -48,6 +56,62 @@ class DetectorHelperTests(unittest.TestCase):
         self.assertTrue(is_incomplete_response_text("Creating image"))
         self.assertTrue(is_incomplete_response_text("Generating image for your request"))
         self.assertFalse(is_incomplete_response_text("Here is the final answer with enough detail."))
+
+
+class DetectorCopyButtonTests(unittest.IsolatedAsyncioTestCase):
+    async def test_latest_turn_copy_ignores_code_block_copy_buttons(self) -> None:
+        playwright_context = async_playwright()
+        if playwright_context is None:
+            self.skipTest("patchright is not installed")
+
+        playwright = await playwright_context.__aenter__()
+        chrome_path = Path(r"C:\Program Files\Google\Chrome\Application\chrome.exe")
+        launch_options = {"headless": True}
+        if chrome_path.exists():
+            launch_options["executable_path"] = str(chrome_path)
+
+        try:
+            browser = await playwright.chromium.launch(**launch_options)
+        except Exception as exc:
+            await playwright_context.__aexit__(None, None, None)
+            self.skipTest(f"browser runtime is not available: {exc}")
+
+        try:
+            context = await browser.new_context()
+            page = await context.new_page()
+            await page.set_content(
+                """
+                <!doctype html>
+                <main>
+                  <article data-message-author-role="assistant" data-message-id="a1">
+                    <div class="markdown">
+                      <p>Here is a full answer.</p>
+                      <pre><code>partial code</code><button id="code-copy" aria-label="Copy code">Copy</button></pre>
+                      <p>More final response text after the code block.</p>
+                    </div>
+                    <button id="turn-copy" data-testid="copy-turn-action-button" aria-label="Copy response">Copy</button>
+                  </article>
+                </main>
+                """
+            )
+            await page.evaluate(
+                """
+                () => {
+                  window.clicked = "";
+                  document.querySelector("#code-copy").addEventListener("click", () => window.clicked = "PARTIAL_CODE");
+                  document.querySelector("#turn-copy").addEventListener("click", () => window.clicked = "FULL_RESPONSE");
+                }
+                """
+            )
+
+            result = await page.evaluate(_CLICK_LATEST_COPY_BUTTON_JS, None)
+            clicked = await page.evaluate("window.clicked || ''")
+
+            self.assertEqual(result.get("reason"), "ok")
+            self.assertEqual(clicked, "FULL_RESPONSE")
+        finally:
+            await browser.close()
+            await playwright_context.__aexit__(None, None, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #42.

## Summary
- Prefer ChatGPT turn-level response copy controls over generic copy buttons.
- Ignore copy buttons inside code blocks so inline Markdown/code copy controls are not mistaken for the assistant response copy button.
- Add a regression test that verifies the latest assistant turn clicks the response-level copy button, not the code-block copy button.
- Add a Chrome/Patchright runbook for reproducing browser-profile and copy-selection checks.

## Verification
- `python -m unittest tests.test_detector_helpers -v`
- `python -m compileall src tests`