### PR TITLE
Improve ChatGPT model switching

### DIFF
--- a/docs/MODEL_SWITCHING.md
+++ b/docs/MODEL_SWITCHING.md
@@ -1,0 +1,83 @@
+# ChatGPT Model Switching
+
+CatGPT supports browser-backed ChatGPT model switching. When a request includes
+a configured model id, CatGPT opens the ChatGPT model picker, selects the
+matching UI label, waits for confirmation, and then sends the prompt.
+
+## Quick Use
+
+OpenAI-compatible request:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer dummy123" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.5-thinking",
+    "messages": [{"role": "user", "content": "Say which mode you are using."}]
+  }'
+```
+
+Native request:
+
+```bash
+curl http://localhost:8000/chat \
+  -H "Authorization: Bearer dummy123" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "gpt-5.5", "message": "Hello from a selected model."}'
+```
+
+List configured model ids:
+
+```bash
+curl http://localhost:8000/v1/models -H "Authorization: Bearer dummy123"
+```
+
+## Configuration
+
+`CHATGPT_MODEL_ALIASES` maps public API ids to visible ChatGPT picker labels:
+
+```env
+CHATGPT_MODEL_ALIASES=gpt-5.5=Instant|Latest 5.5|5.5|GPT-5.5,gpt-5.5-thinking=Thinking,o3=o3
+```
+
+Format:
+
+```text
+public_id=Primary UI Label|Alternate UI Label|Another Alternate
+```
+
+If a request uses `catgpt-browser`, CatGPT keeps the current browser-selected
+model unless `CHATGPT_DEFAULT_MODEL` is set:
+
+```env
+CHATGPT_DEFAULT_MODEL=gpt-5.5-thinking
+```
+
+By default, if a configured model is not visible in the account's picker, CatGPT
+logs the visible options and continues with the currently selected browser
+model. To fail the request instead:
+
+```env
+CHATGPT_MODEL_SWITCH_STRICT=true
+```
+
+`CHATGPT_MODEL_SWITCH_TIMEOUT` is measured in milliseconds and controls how long
+CatGPT waits for the selected model label to appear after clicking an option.
+For example:
+
+```env
+CHATGPT_MODEL_SWITCH_TIMEOUT=10000  # 10 seconds
+```
+
+Do not set `CHATGPT_MODEL_SWITCH_TIMEOUT=1` expecting one second; that is 1 ms.
+
+## Notes
+
+- Model availability depends on the logged-in ChatGPT account and plan.
+- UI labels change over time. Update `CHATGPT_MODEL_ALIASES` when ChatGPT
+  renames picker items.
+- The CLI also supports `/model <name>`, which changes the model id sent to the
+  API for later messages.
+- Issue #8 is implemented by `src/chatgpt/model_registry.py` and
+  `ChatGPTClient.ensure_model()`.

--- a/docs/MODEL_SWITCHING.md
+++ b/docs/MODEL_SWITCHING.md
@@ -75,6 +75,9 @@ Do not set `CHATGPT_MODEL_SWITCH_TIMEOUT=1` expecting one second; that is 1 ms.
 ## Notes
 
 - Model availability depends on the logged-in ChatGPT account and plan.
+- Versioned GPT labels such as `5.2` may live under the picker option
+  `Configure...` rather than in the first menu. CatGPT opens Configure and
+  selects the requested version from the dialog's Model dropdown when needed.
 - UI labels change over time. Update `CHATGPT_MODEL_ALIASES` when ChatGPT
   renames picker items.
 - The CLI also supports `/model <name>`, which changes the model id sent to the

--- a/src/chatgpt/client.py
+++ b/src/chatgpt/client.py
@@ -367,8 +367,11 @@ class ChatGPTClient:
             current_after = await self._detect_current_model_label()
             if not self._label_matches_model_option(current_after, target):
                 await self._dismiss_model_picker()
-                self._handle_model_switch_failure(f"Model switch to '{target.ui_label}' could not be confirmed")
-                return
+                await asyncio.sleep(1.0)
+                current_after = await self._detect_current_model_label()
+                if not self._label_matches_model_option(current_after, target):
+                    self._handle_model_switch_failure(f"Model switch to '{target.ui_label}' could not be confirmed")
+                    return
 
         await self._dismiss_model_picker()
         self._last_model_label = target.ui_label
@@ -948,11 +951,111 @@ class ChatGPTClient:
             "o3",
             "o4",
         ]
-        if await self._click_top_button_by_text(hints):
+        if await self._click_model_picker_button_by_text(hints):
             await asyncio.sleep(0.25)
             return await self._model_picker_is_open()
 
         return False
+
+    async def _click_model_picker_button_by_text(self, hints: list[str]) -> bool:
+        """Click the ChatGPT model picker trigger by current/target model text."""
+        filtered_hints = [hint for hint in hints if (hint or "").strip()]
+        if not filtered_hints:
+            return False
+
+        candidate = await self._page.evaluate(
+            r"""
+            (hints) => {
+                const normalize = (value) =>
+                    (value || "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+                const wanted = (hints || []).map(normalize).filter(Boolean);
+                const modelish = /(gpt|o[0-9]|instant|thinking|latest|auto|model|mini|nano|5\.[0-9]|4\.[0-9])/i;
+                const isVisible = (el) => {
+                    if (!el) return false;
+                    const rect = el.getBoundingClientRect();
+                    const style = window.getComputedStyle(el);
+                    return rect.width > 0 &&
+                        rect.height > 0 &&
+                        style.visibility !== "hidden" &&
+                        style.display !== "none";
+                };
+                const isInsideSidebar = (el) => Boolean(el.closest(
+                    "nav, aside, [data-testid='sidebar'], [data-testid*='history' i]"
+                ));
+                const clickable = Array.from(document.querySelectorAll([
+                    "button",
+                    "[role='button']",
+                    "[aria-haspopup='menu']",
+                    "[data-testid*='model' i]",
+                ].join(",")));
+                const matches = [];
+                for (const el of clickable) {
+                    if (!isVisible(el)) continue;
+                    const rect = el.getBoundingClientRect();
+                    if (rect.top < 0 || rect.top > window.innerHeight - 40) continue;
+                    if (rect.left < 240 && isInsideSidebar(el)) continue;
+
+                    const primaryText = ((el.innerText || el.textContent || "")
+                        .split(/\n+/)
+                        .map((part) => part.trim())
+                        .filter(Boolean)[0] || "").trim();
+                    const text = [
+                        primaryText,
+                        el.innerText || "",
+                        el.textContent || "",
+                        el.getAttribute("aria-label") || "",
+                        el.getAttribute("title") || "",
+                        el.getAttribute("data-testid") || "",
+                    ].join(" ").trim();
+                    const normalizedText = normalize(text);
+                    const normalizedPrimary = normalize(primaryText);
+                    if (!normalizedText) continue;
+
+                    let score = 0;
+                    for (const hint of wanted) {
+                        if (!normalizedText.includes(hint)) continue;
+                        score = Math.max(
+                            score,
+                            normalizedPrimary === hint
+                                ? 90
+                                : normalizedText === hint
+                                  ? 75
+                                  : normalizedPrimary.startsWith(hint)
+                                    ? 60
+                                    : normalizedText.startsWith(hint)
+                                      ? 50
+                                      : 25,
+                        );
+                    }
+                    if (modelish.test(text)) score += 25;
+                    if ((el.getAttribute("aria-haspopup") || "").toLowerCase() === "menu") score += 40;
+                    if ((el.getAttribute("data-testid") || "").toLowerCase().includes("model")) score += 35;
+                    if (rect.left > 240) score += 15;
+                    if (rect.top < 120 || rect.top > window.innerHeight / 2) score += 10;
+
+                    if (score < 35) continue;
+                    matches.push({
+                        score,
+                        top: rect.top,
+                        left: rect.left,
+                        x: rect.left + rect.width / 2,
+                        y: rect.top + rect.height / 2,
+                        label: primaryText,
+                    });
+                }
+                matches.sort((a, b) => b.score - a.score || b.left - a.left || a.top - b.top);
+                return matches[0] || null;
+            }
+            """,
+            filtered_hints,
+        )
+        if not isinstance(candidate, dict) or "x" not in candidate or "y" not in candidate:
+            return False
+
+        await self._page.mouse.move(float(candidate["x"]), float(candidate["y"]), steps=8)
+        await asyncio.sleep(0.05)
+        await self._page.mouse.click(float(candidate["x"]), float(candidate["y"]))
+        return True
 
     async def _click_top_button_by_text(self, hints: list[str]) -> bool:
         """Click a visible top-of-page button whose label best matches the hints."""

--- a/src/chatgpt/client.py
+++ b/src/chatgpt/client.py
@@ -339,7 +339,12 @@ class ChatGPTClient:
             configure_opened = await self._click_menu_text("Configure")
             if configure_opened:
                 await asyncio.sleep(0.5)
-                switched = await self._select_model_from_configure_dialog(target.ui_labels)
+                switched = await self._select_model_from_configure_dialog(
+                    target.ui_labels,
+                    target_version_label=target_version_label,
+                )
+                if switched and target_version_label:
+                    self._last_model_version_label = target_version_label
 
         if not switched:
             self._unavailable_model_keys.update(unavailable_keys)
@@ -361,17 +366,28 @@ class ChatGPTClient:
                 await self._dismiss_model_picker()
                 self._handle_model_switch_failure(detail)
                 return
+            self._last_model_version_label = target_version_label
 
-        confirmed = await self._wait_for_model_label(target.ui_labels)
-        if not confirmed:
-            current_after = await self._detect_current_model_label()
-            if not self._label_matches_model_option(current_after, target):
-                await self._dismiss_model_picker()
-                await asyncio.sleep(1.0)
+        if self._is_configure_only_version_option(target, target_version_label):
+            confirmed = self._model_version_is_current(target_version_label)
+            if not confirmed:
+                self._handle_model_switch_failure(
+                    f"Model switch to '{target.ui_label}' could not be confirmed via Configure"
+                )
+                return
+        else:
+            confirmed = await self._wait_for_model_label(target.ui_labels)
+            if not confirmed:
                 current_after = await self._detect_current_model_label()
                 if not self._label_matches_model_option(current_after, target):
-                    self._handle_model_switch_failure(f"Model switch to '{target.ui_label}' could not be confirmed")
-                    return
+                    await self._dismiss_model_picker()
+                    await asyncio.sleep(1.0)
+                    current_after = await self._detect_current_model_label()
+                    if not self._label_matches_model_option(current_after, target):
+                        self._handle_model_switch_failure(
+                            f"Model switch to '{target.ui_label}' could not be confirmed"
+                        )
+                        return
 
         await self._dismiss_model_picker()
         self._last_model_label = target.ui_label
@@ -816,6 +832,18 @@ class ChatGPTClient:
         target_version = normalize_model_token(target_version_label)
         return primary != target_version
 
+    def _is_configure_only_version_option(self, option, target_version_label: str) -> bool:
+        """
+        Return whether the requested option is a version selected inside Configure.
+
+        ChatGPT can keep showing a top-level mode label after selecting a concrete
+        version from Configure, so pure version requests confirm by configured
+        version rather than by the composer button text.
+        """
+        target_version = normalize_model_token(target_version_label)
+        primary = normalize_model_token(getattr(option, "ui_label", ""))
+        return bool(target_version and primary == target_version)
+
     async def _dismiss_model_picker(self) -> None:
         """Close any open model picker menu/dialog before interacting with the composer."""
         for _ in range(2):
@@ -1147,9 +1175,15 @@ class ChatGPTClient:
                 return True
         return False
 
-    async def _select_model_from_configure_dialog(self, target_labels: tuple[str, ...]) -> bool:
+    async def _select_model_from_configure_dialog(
+        self,
+        target_labels: tuple[str, ...],
+        target_version_label: str = "",
+    ) -> bool:
         """Select a model from the Pro Intelligence -> Model dropdown dialog."""
         target_tokens = {normalize_model_token(label) for label in target_labels}
+        if target_version_label:
+            target_tokens.add(normalize_model_token(target_version_label))
         version_tokens = {
             token
             for token in target_tokens
@@ -1162,16 +1196,43 @@ class ChatGPTClient:
                 return False
 
             await asyncio.sleep(0.4)
-            version_selected = await self._click_model_option(target_labels)
+            version_labels = self._configure_version_click_labels(target_labels, target_version_label)
+            version_selected = await self._click_model_option(version_labels)
             if not version_selected:
                 return False
 
             await asyncio.sleep(0.4)
-            target_version_label = next(iter(version_tokens))
-            radio_selected = await self._click_configure_radio_for_version(target_version_label)
+            radio_selected = await self._click_configure_radio_for_version(
+                target_version_label or version_labels[0]
+            )
             return radio_selected or version_selected
 
         return await self._click_model_option(target_labels)
+
+    def _configure_version_click_labels(
+        self,
+        target_labels: tuple[str, ...],
+        target_version_label: str = "",
+    ) -> tuple[str, ...]:
+        """Return labels to try when selecting a concrete model version."""
+        ordered: list[str] = []
+        if target_version_label:
+            ordered.append(target_version_label)
+        for label in target_labels:
+            match = re.search(r"(?:gpt[- ]*)?((?:[45]\.\d+)|o\d+)", label, flags=re.IGNORECASE)
+            if match:
+                ordered.append(match.group(1))
+            ordered.append(label)
+
+        seen: set[str] = set()
+        result: list[str] = []
+        for label in ordered:
+            normalized = normalize_model_token(label)
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            result.append(label)
+        return tuple(result)
 
     async def _ensure_configured_model_version(self, target_version_label: str) -> bool:
         """Open Configure and select the requested model-version label."""
@@ -1187,7 +1248,13 @@ class ChatGPTClient:
             return False
 
         await asyncio.sleep(0.5)
-        return await self._select_model_from_configure_dialog((target_version_label,))
+        version_configured = await self._select_model_from_configure_dialog(
+            (target_version_label,),
+            target_version_label=target_version_label,
+        )
+        if version_configured:
+            self._last_model_version_label = target_version_label
+        return version_configured
 
     async def _click_configure_model_combobox(self) -> bool:
         """Open the model-version combobox in ChatGPT's Configure dialog."""
@@ -1335,9 +1402,12 @@ class ChatGPTClient:
                     "[role='menuitem']",
                     "[role='option']",
                     "[role='radio']",
+                    "[role='button']",
                     "button",
                     "[data-radix-collection-item]",
+                    "[cmdk-item]",
                     "li",
+                    "div",
                 ];
                 const matches = [];
                 for (const selector of selectors) {
@@ -1372,12 +1442,13 @@ class ChatGPTClient:
                             score,
                             top: rect.top,
                             left: rect.left,
+                            area: rect.width * rect.height,
                             x: rect.left + rect.width / 2,
                             y: rect.top + rect.height / 2,
                         });
                     }
                 }
-                matches.sort((a, b) => b.score - a.score || a.top - b.top || a.left - b.left);
+                matches.sort((a, b) => b.score - a.score || a.area - b.area || a.top - b.top || a.left - b.left);
                 const best = matches[0];
                 return best || null;
             }

--- a/src/selectors.py
+++ b/src/selectors.py
@@ -34,6 +34,8 @@ class Selectors:
         "button[aria-haspopup='menu']:has-text('Instant')",
         "button[aria-haspopup='menu']:has-text('Thinking')",
         "button[aria-haspopup='menu']:has-text('Auto')",
+        "button[aria-haspopup='menu']:has-text('5.')",
+        "button[aria-haspopup='menu']:has-text('GPT')",
     ]
 
     # ── Assistant response messages ─────────────────────────────

--- a/tests/test_chatgpt_client_model_switch.py
+++ b/tests/test_chatgpt_client_model_switch.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import sys
 import types
 import unittest
+import importlib.util
+from pathlib import Path
 from unittest.mock import patch
 
 # Provide a minimal patchright stub so client tests can import browser modules
 # without requiring browser automation dependencies.
-if "patchright" not in sys.modules:
+if "patchright" not in sys.modules and importlib.util.find_spec("patchright.async_api") is None:
     patchright_mod = types.ModuleType("patchright")
     async_api_mod = types.ModuleType("patchright.async_api")
     async_api_mod.Page = object
@@ -37,6 +39,11 @@ if "pydantic" not in sys.modules:
 
 from src.chatgpt.client import ChatGPTClient
 from src.config import Config
+
+try:
+    from patchright.async_api import async_playwright
+except ImportError:
+    async_playwright = None
 
 
 async def _noop_sleep(*_args, **_kwargs) -> None:
@@ -123,6 +130,63 @@ class ChatGPTClientModelSwitchTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("Could not open ChatGPT model picker", str(ctx.exception))
         self.assertEqual(page.keyboard.presses, ["Escape", "Escape"])
+
+    async def test_model_picker_fallback_clicks_version_labeled_composer_button(self) -> None:
+        if async_playwright is None:
+            self.skipTest("patchright is not installed")
+
+        playwright_context = async_playwright()
+        chrome_path = Path(r"C:\Program Files\Google\Chrome\Application\chrome.exe")
+        launch_options = {"headless": True}
+        if chrome_path.exists():
+            launch_options["executable_path"] = str(chrome_path)
+
+        playwright = await playwright_context.__aenter__()
+        try:
+            try:
+                browser = await playwright.chromium.launch(**launch_options)
+            except Exception as exc:
+                self.skipTest(f"browser runtime is not available: {exc}")
+
+            try:
+                page = await (await browser.new_context()).new_page()
+                await page.set_content(
+                    """
+                    <!doctype html>
+                    <main style="min-height: 720px">
+                      <nav>
+                        <button aria-haspopup="menu" style="position:absolute;left:6px;top:132px">Recents</button>
+                      </nav>
+                      <button id="model-picker" aria-haspopup="menu"
+                              style="position:absolute;left:910px;top:420px;width:90px;height:36px">5.1</button>
+                    </main>
+                    """
+                )
+                await page.evaluate(
+                    """
+                    () => {
+                      window.clicked = "";
+                      document.querySelector("#model-picker").addEventListener("click", () => {
+                        window.clicked = "model-picker";
+                        const menu = document.createElement("div");
+                        menu.setAttribute("role", "menuitem");
+                        menu.textContent = "Thinking";
+                        document.body.appendChild(menu);
+                      });
+                    }
+                    """
+                )
+                client = ChatGPTClient(page)  # type: ignore[arg-type]
+
+                clicked = await client._click_model_picker_button_by_text(["5.1", "Thinking", "model"])
+                selected = await page.evaluate("window.clicked")
+
+                self.assertTrue(clicked)
+                self.assertEqual(selected, "model-picker")
+            finally:
+                await browser.close()
+        finally:
+            await playwright_context.__aexit__(None, None, None)
 
 
 if __name__ == "__main__":

--- a/tests/test_chatgpt_client_model_switch.py
+++ b/tests/test_chatgpt_client_model_switch.py
@@ -100,6 +100,40 @@ class _FakePage:
         return self.visible_options
 
 
+class _ConfigureOnlyClient(ChatGPTClient):
+    def __init__(self, page) -> None:
+        super().__init__(page)
+        self.configure_calls: list[tuple[tuple[str, ...], str]] = []
+        self.wait_for_label_calls = 0
+
+    async def _detect_current_model_label(self) -> str:
+        return "Thinking"
+
+    async def _open_model_picker(self, _target_label: str, current_label: str = "") -> bool:
+        return True
+
+    async def _click_model_option(self, _target_labels: tuple[str, ...]) -> bool:
+        return False
+
+    async def _click_menu_text(self, target_text: str) -> bool:
+        return target_text == "Configure"
+
+    async def _select_model_from_configure_dialog(
+        self,
+        target_labels: tuple[str, ...],
+        target_version_label: str = "",
+    ) -> bool:
+        self.configure_calls.append((target_labels, target_version_label))
+        return True
+
+    async def _wait_for_model_label(self, _target_labels: tuple[str, ...]) -> bool:
+        self.wait_for_label_calls += 1
+        return False
+
+    async def _dismiss_model_picker(self) -> None:
+        return None
+
+
 class ChatGPTClientModelSwitchTests(unittest.IsolatedAsyncioTestCase):
     async def test_missing_model_option_falls_back_and_caches_when_not_strict(self) -> None:
         page = _FakePage(open_picker=True, visible_options=["GPT-5", "o3"])
@@ -130,6 +164,29 @@ class ChatGPTClientModelSwitchTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("Could not open ChatGPT model picker", str(ctx.exception))
         self.assertEqual(page.keyboard.presses, ["Escape", "Escape"])
+
+    async def test_version_option_uses_configure_dropdown_confirmation(self) -> None:
+        page = _FakePage(open_picker=True)
+        client = _ConfigureOnlyClient(page)  # type: ignore[arg-type]
+
+        with patch.object(Config, "CHATGPT_MODEL_ALIASES", "gpt-5.2=5.2|GPT-5.2"), patch.object(
+            Config,
+            "CHATGPT_MODEL_SWITCH_STRICT",
+            True,
+        ), patch("src.chatgpt.client.asyncio.sleep", _noop_sleep):
+            await client.ensure_model("gpt-5.2")
+
+        self.assertEqual(client.configure_calls, [(("5.2", "GPT-5.2"), "5.2")])
+        self.assertEqual(client._last_model_label, "5.2")
+        self.assertEqual(client._last_model_version_label, "5.2")
+        self.assertEqual(client.wait_for_label_calls, 0)
+
+    def test_configure_version_click_labels_prioritize_dotted_version(self) -> None:
+        client = ChatGPTClient(_FakePage())  # type: ignore[arg-type]
+
+        labels = client._configure_version_click_labels(("Instant", "Latest 5.5", "GPT-5.5"), "5.5")
+
+        self.assertEqual(labels[:3], ("5.5", "Instant", "Latest 5.5"))
 
     async def test_model_picker_fallback_clicks_version_labeled_composer_button(self) -> None:
         if async_playwright is None:


### PR DESCRIPTION
Closes #8.

## Summary
- Add browser-backed ChatGPT model switching docs and tests.
- Improve model picker discovery when the visible trigger is a version label such as `5.1`, `5.2`, or a GPT label rather than `Instant`/`Thinking`.
- Support versioned models that live behind `Configure...` by opening the Configure dialog and selecting the requested version from its Model dropdown.
- Add a 1-second retry path for label confirmation when the UI does not update immediately.

## Model configuration
Set the default browser model with environment variables in Compose or `.env`:

```yaml
environment:
  CHATGPT_DEFAULT_MODEL: gpt-5.2
  CHATGPT_MODEL_SWITCH_STRICT: "false"
  CHATGPT_MODEL_SWITCH_TIMEOUT: "10000"
```

`CHATGPT_MODEL_ALIASES` maps API model IDs to UI labels. Example:

```yaml
environment:
  CHATGPT_MODEL_ALIASES: "gpt-5.2=5.2|GPT-5.2,gpt-5.2-thinking=Thinking|5.2 Thinking|GPT-5.2 Thinking,gpt-5.1=5.1|GPT-5.1"
```

Clients can also request a model per call with the OpenAI-compatible `model` field, e.g. `gpt-5.2` or `gpt-5.2-thinking`. `CHATGPT_MODEL_SWITCH_TIMEOUT` is milliseconds, so `10000` means 10 seconds; `1` means 1 ms.

## Verification
- `python -m unittest tests.test_chatgpt_client_model_switch -v`
- `python -m compileall src tests`
- Live headed check with the saved ChatGPT profile selected `gpt-5.2` through Configure and showed `5.2 Thinking` in the UI.
