### PR TITLE
Merge Dependabot dependency updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ playwright-stealth>=2.0.3
 
 # TUI (Phase 2)
 textual>=8.2.6
-typer>=0.25.1
+typer>=0.26.5
 rich>=15.0.0
 
 # API (Phase 3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ PyMuPDF>=1.27.2.3
 # OpenAI-compatible testing
 openai>=2.36.0
 langchain-openai>=1.2.1
-langchain>=1.3.0
+langchain>=1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,6 @@ Pillow>=12.2.0
 PyMuPDF>=1.27.2.3
 
 # OpenAI-compatible testing
-openai>=2.36.0
+openai>=2.40.0
 langchain-openai>=1.2.1
 langchain>=1.3.2


### PR DESCRIPTION
Replaces the closed Dependabot PRs #39, #40, and #41. Those PRs could not be reopened after closure, so this branch cherry-picks their original Dependabot commits onto current `main`.

## Updates
- `langchain>=1.3.2` from PR #39
- `openai>=2.40.0` from PR #40
- `typer>=0.26.5` from PR #41

## Verification
- `python -m unittest tests.test_detector_helpers tests.test_auto_login tests.test_chatgpt_client_model_switch -v`
- `python -m compileall src tests`
