### PR TITLE
Fix table copy buttons in ChatGPT detector

### DIFF
--- a/src/chatgpt/detector.py
+++ b/src/chatgpt/detector.py
@@ -74,16 +74,27 @@ _CONVERSATION_SNAPSHOT_JS = r"""
         return Boolean(el.closest("pre, code, .code-block, [data-testid*='code' i]")) ||
             label.includes("copy code");
     };
+    const isTableCopyButton = (el) => {
+        if (!el) return false;
+        const label = [
+            el.getAttribute("aria-label") || "",
+            el.getAttribute("data-testid") || "",
+            textOf(el).slice(0, 80)
+        ].join(" ").toLowerCase();
+        return Boolean(el.closest("._tableContainer, ._tableWrapper, table")) ||
+            label.includes("copy table");
+    };
+    const isTurnCopyButton = (el) => !isCodeCopyButton(el) && !isTableCopyButton(el);
 
     const findTurnCopyButton = (root) => {
         const preferred = Array.from(root.querySelectorAll(preferredTurnCopySelector))
-            .filter((button) => !isCodeCopyButton(button));
+            .filter(isTurnCopyButton);
         const visiblePreferred = preferred.find(isVisible);
         if (visiblePreferred) return visiblePreferred;
         if (preferred.length) return preferred[preferred.length - 1];
 
         const fallback = Array.from(root.querySelectorAll(copySelector))
-            .filter((button) => !isCodeCopyButton(button));
+            .filter(isTurnCopyButton);
         const visibleFallback = fallback.filter(isVisible);
         return visibleFallback[visibleFallback.length - 1] || fallback[fallback.length - 1] || null;
     };
@@ -353,15 +364,26 @@ _CLICK_LATEST_COPY_BUTTON_JS = r"""
         return Boolean(el.closest("pre, code, .code-block, [data-testid*='code' i]")) ||
             label.includes("copy code");
     };
+    const isTableCopyButton = (el) => {
+        if (!el) return false;
+        const label = [
+            el.getAttribute("aria-label") || "",
+            el.getAttribute("data-testid") || "",
+            textOf(el).slice(0, 80)
+        ].join(" ").toLowerCase();
+        return Boolean(el.closest("._tableContainer, ._tableWrapper, table")) ||
+            label.includes("copy table");
+    };
+    const isTurnCopyButton = (el) => !isCodeCopyButton(el) && !isTableCopyButton(el);
     const findTurnCopyButton = (root) => {
         const preferred = Array.from(root.querySelectorAll(preferredTurnCopySelector))
-            .filter((button) => !isCodeCopyButton(button));
+            .filter(isTurnCopyButton);
         const visiblePreferred = preferred.find(isVisible);
         if (visiblePreferred) return visiblePreferred;
         if (preferred.length) return preferred[preferred.length - 1];
 
         const fallback = Array.from(root.querySelectorAll(copySelector))
-            .filter((button) => !isCodeCopyButton(button));
+            .filter(isTurnCopyButton);
         const visibleFallback = fallback.filter(isVisible);
         return visibleFallback[visibleFallback.length - 1] || fallback[fallback.length - 1] || null;
     };
@@ -468,7 +490,7 @@ _CLICK_LATEST_COPY_BUTTON_JS = r"""
         const nearby = Array.from(document.querySelectorAll(copySelector))
             .filter((candidate) => {
                 const rect = candidate.getBoundingClientRect();
-                return !isCodeCopyButton(candidate) &&
+                return isTurnCopyButton(candidate) &&
                     rect.top >= rootRect.top - 10 &&
                     rect.top <= rootRect.bottom + 120 &&
                     rect.left >= rootRect.left - 60 &&

--- a/src/selectors.py
+++ b/src/selectors.py
@@ -96,10 +96,9 @@ class Selectors:
     # after the full response has been generated.
     COPY_BUTTON = [
         "button[data-testid='copy-turn-action-button']",
-        "button[data-testid*='copy' i]",
+        "button[data-testid*='copy-turn' i]",
         "button[aria-label='Copy message']",
-        "button[aria-label='Copy']",
-        "button[aria-label*='Copy' i]",
+        "button[aria-label='Copy response']",
     ]
 
     # ── Generated images inside assistant responses ───────────────────

--- a/tests/test_detector_helpers.py
+++ b/tests/test_detector_helpers.py
@@ -38,6 +38,7 @@ from patchright.async_api import async_playwright
 
 from src.chatgpt.detector import (
     _CLICK_LATEST_COPY_BUTTON_JS,
+    _conversation_snapshot,
     is_incomplete_response_text,
     normalize_assistant_text,
 )
@@ -59,59 +60,139 @@ class DetectorHelperTests(unittest.TestCase):
 
 
 class DetectorCopyButtonTests(unittest.IsolatedAsyncioTestCase):
-    async def test_latest_turn_copy_ignores_code_block_copy_buttons(self) -> None:
+    async def asyncSetUp(self) -> None:
         playwright_context = async_playwright()
         if playwright_context is None:
             self.skipTest("patchright is not installed")
 
-        playwright = await playwright_context.__aenter__()
+        self.playwright_context = playwright_context
+        self.playwright = await playwright_context.__aenter__()
         chrome_path = Path(r"C:\Program Files\Google\Chrome\Application\chrome.exe")
         launch_options = {"headless": True}
         if chrome_path.exists():
             launch_options["executable_path"] = str(chrome_path)
 
         try:
-            browser = await playwright.chromium.launch(**launch_options)
+            self.browser = await self.playwright.chromium.launch(**launch_options)
         except Exception as exc:
             await playwright_context.__aexit__(None, None, None)
             self.skipTest(f"browser runtime is not available: {exc}")
 
-        try:
-            context = await browser.new_context()
-            page = await context.new_page()
-            await page.set_content(
-                """
-                <!doctype html>
-                <main>
-                  <article data-message-author-role="assistant" data-message-id="a1">
-                    <div class="markdown">
-                      <p>Here is a full answer.</p>
-                      <pre><code>partial code</code><button id="code-copy" aria-label="Copy code">Copy</button></pre>
-                      <p>More final response text after the code block.</p>
+    async def asyncTearDown(self) -> None:
+        await self.browser.close()
+        await self.playwright_context.__aexit__(None, None, None)
+
+    async def test_latest_turn_copy_ignores_code_block_copy_buttons(self) -> None:
+        context = await self.browser.new_context()
+        page = await context.new_page()
+        await page.set_content(
+            """
+            <!doctype html>
+            <main>
+              <article data-message-author-role="assistant" data-message-id="a1">
+                <div class="markdown">
+                  <p>Here is a full answer.</p>
+                  <pre><code>partial code</code><button id="code-copy" aria-label="Copy code">Copy</button></pre>
+                  <p>More final response text after the code block.</p>
+                </div>
+                <button id="turn-copy" data-testid="copy-turn-action-button" aria-label="Copy response">Copy</button>
+              </article>
+            </main>
+            """
+        )
+        await page.evaluate(
+            """
+            () => {
+              window.clicked = "";
+              document.querySelector("#code-copy").addEventListener("click", () => window.clicked = "PARTIAL_CODE");
+              document.querySelector("#turn-copy").addEventListener("click", () => window.clicked = "FULL_RESPONSE");
+            }
+            """
+        )
+
+        result = await page.evaluate(_CLICK_LATEST_COPY_BUTTON_JS, None)
+        clicked = await page.evaluate("window.clicked || ''")
+
+        self.assertEqual(result.get("reason"), "ok")
+        self.assertEqual(clicked, "FULL_RESPONSE")
+        await context.close()
+
+    async def test_latest_turn_copy_ignores_table_copy_button(self) -> None:
+        context = await self.browser.new_context()
+        page = await context.new_page()
+        await page.set_content(
+            """
+            <!doctype html>
+            <main>
+              <article data-message-author-role="assistant" data-message-id="a1">
+                <div class="markdown">
+                  <p>Here is a full answer with a markdown table.</p>
+                  <div class="_tableContainer">
+                    <div tabindex="-1" class="group _tableWrapper flex flex-col-reverse w-fit">
+                      <table data-start="1" data-end="42">
+                        <thead><tr><th>Column1</th><th>Column2</th></tr></thead>
+                        <tbody><tr><td>one</td><td>two</td></tr></tbody>
+                      </table>
+                      <div class="relative h-0 self-end select-none">
+                        <div class="absolute end-0 flex items-end">
+                          <span data-state="closed">
+                            <button id="table-copy" aria-label="Copy Table">Copy Table</button>
+                          </span>
+                        </div>
+                      </div>
                     </div>
-                    <button id="turn-copy" data-testid="copy-turn-action-button" aria-label="Copy response">Copy</button>
-                  </article>
-                </main>
-                """
-            )
-            await page.evaluate(
-                """
-                () => {
-                  window.clicked = "";
-                  document.querySelector("#code-copy").addEventListener("click", () => window.clicked = "PARTIAL_CODE");
-                  document.querySelector("#turn-copy").addEventListener("click", () => window.clicked = "FULL_RESPONSE");
-                }
-                """
-            )
+                  </div>
+                  <p>More final response text after the table.</p>
+                </div>
+                <button id="turn-copy" data-testid="copy-turn-action-button" aria-label="Copy response">Copy</button>
+              </article>
+            </main>
+            """
+        )
+        await page.evaluate(
+            """
+            () => {
+              window.clicked = "";
+              document.querySelector("#table-copy").addEventListener("click", () => window.clicked = "TABLE_ONLY");
+              document.querySelector("#turn-copy").addEventListener("click", () => window.clicked = "FULL_RESPONSE");
+            }
+            """
+        )
 
-            result = await page.evaluate(_CLICK_LATEST_COPY_BUTTON_JS, None)
-            clicked = await page.evaluate("window.clicked || ''")
+        result = await page.evaluate(_CLICK_LATEST_COPY_BUTTON_JS, None)
+        clicked = await page.evaluate("window.clicked || ''")
 
-            self.assertEqual(result.get("reason"), "ok")
-            self.assertEqual(clicked, "FULL_RESPONSE")
-        finally:
-            await browser.close()
-            await playwright_context.__aexit__(None, None, None)
+        self.assertEqual(result.get("reason"), "ok")
+        self.assertEqual(clicked, "FULL_RESPONSE")
+        await context.close()
+
+    async def test_table_copy_button_does_not_signal_response_complete(self) -> None:
+        context = await self.browser.new_context()
+        page = await context.new_page()
+        await page.set_content(
+            """
+            <!doctype html>
+            <main>
+              <article data-message-author-role="assistant" data-message-id="a1">
+                <div class="markdown">
+                  <p>Streaming response with a table.</p>
+                  <div class="_tableContainer">
+                    <div class="_tableWrapper">
+                      <table><tbody><tr><td>partial</td></tr></tbody></table>
+                      <div><button id="table-copy" aria-label="Copy Table">Copy Table</button></div>
+                    </div>
+                  </div>
+                </div>
+              </article>
+            </main>
+            """
+        )
+
+        snapshot = await _conversation_snapshot(page)
+
+        self.assertEqual(snapshot.get("copyButtonCount"), 0)
+        self.assertFalse(snapshot["latestAssistant"]["hasCopyButton"])
+        await context.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ignore ChatGPT markdown table copy controls when detecting response-level copy readiness
- avoid clicking \Copy Table\ during latest assistant extraction
- add Playwright regression coverage for table copy controls and completion detection

## Tests
- \python -m pytest tests\\test_detector_helpers.py -q\

Closes #42