### PR TITLE
Sync with upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Thumbs.db
 
 # ── Nix ──
 result
+docs/GIT_HISTORY_CLEANUP_NOTES.md

--- a/scripts/check_page_state.py
+++ b/scripts/check_page_state.py
@@ -1,0 +1,50 @@
+"""Quick diagnostic: check what's actually on the page right now."""
+import asyncio, sys
+sys.path.insert(0, ".")
+from patchright.async_api import async_playwright
+
+async def main():
+    pw = await async_playwright().start()
+    browser = await pw.chromium.connect_over_cdp("http://127.0.0.1:9222")
+    page = [p for p in browser.contexts[0].pages if "chatgpt.com" in p.url][0]
+    
+    result = await page.evaluate("""
+        () => {
+            const turns = document.querySelectorAll('section[data-testid^="conversation-turn-"]');
+            const info = [];
+            for (let i = 0; i < turns.length; i++) {
+                const t = turns[i];
+                const role = t.getAttribute('data-turn') || 'unknown';
+                const text = (t.innerText || '').trim().substring(0, 150);
+                const copyBtn = t.querySelector('button[data-testid="copy-turn-action-button"], button[aria-label="Copy"], button[aria-label="Copy message"]');
+                const allBtns = t.querySelectorAll('button');
+                const btnTexts = Array.from(allBtns).map(b => (b.getAttribute('aria-label') || b.innerText || '').trim().substring(0, 30)).filter(Boolean);
+                const stableId = t.getAttribute('data-turn-id') || t.getAttribute('data-testid') || '';
+                info.push({
+                    index: i,
+                    role,
+                    stableId,
+                    textLen: text.length,
+                    textPreview: text.substring(0, 100),
+                    hasCopyBtn: !!copyBtn,
+                    buttonCount: allBtns.length,
+                    buttonLabels: btnTexts.slice(0, 8),
+                });
+            }
+            return info;
+        }
+    """)
+    
+    print(f"\n{'='*70}")
+    print(f"PAGE STATE: {len(result)} turns")
+    print(f"{'='*70}")
+    for t in result:
+        copy_status = "✓ COPY" if t["hasCopyBtn"] else "✗ no copy"
+        print(f"\n  Turn {t['index']} ({t['role']}) [{copy_status}] — {t['textLen']} chars")
+        print(f"    ID: {t['stableId']}")
+        print(f"    Text: {t['textPreview'][:80]}")
+        print(f"    Buttons ({t['buttonCount']}): {t['buttonLabels']}")
+    
+    await pw.stop()
+
+asyncio.run(main())

--- a/scripts/diagnose_chatgpt.py
+++ b/scripts/diagnose_chatgpt.py
@@ -1,0 +1,316 @@
+"""
+Diagnose WHY ChatGPT's backend isn't responding on 2nd message.
+Check for hidden errors, rate limits, broken connections.
+Then test in a completely fresh chat.
+"""
+import asyncio, sys, time
+sys.path.insert(0, ".")
+from patchright.async_api import async_playwright
+
+async def main():
+    pw = await async_playwright().start()
+    browser = await pw.chromium.connect_over_cdp("http://127.0.0.1:9222")
+    page = [p for p in browser.contexts[0].pages if "chatgpt.com" in p.url][0]
+    
+    # 1. Check for any error state on the page
+    print("=" * 60)
+    print("STEP 1: Check for errors/overlays on current page")
+    print("=" * 60)
+    
+    errors = await page.evaluate("""
+        () => {
+            const info = {};
+            
+            // Check for error messages anywhere
+            const allText = document.body.innerText;
+            const errorPatterns = [
+                'Something went wrong', 'rate limit', 'too many', 
+                'try again', 'error', 'couldn\\'t', 'failed',
+                'network error', 'unable to', 'capacity'
+            ];
+            info.errorPatterns = errorPatterns.filter(p => 
+                allText.toLowerCase().includes(p.toLowerCase())
+            );
+            
+            // Check for dialogs/modals
+            info.dialogs = [];
+            document.querySelectorAll('[role="dialog"], [role="alertdialog"], dialog').forEach(d => {
+                info.dialogs.push((d.innerText || '').trim().substring(0, 200));
+            });
+            
+            // Check for retry/regenerate buttons
+            info.retryButtons = [];
+            document.querySelectorAll('button').forEach(btn => {
+                const text = (btn.innerText || '').trim().toLowerCase();
+                if (text.includes('retry') || text.includes('regenerate') || 
+                    text.includes('try again') || text.includes('resend')) {
+                    info.retryButtons.push(text);
+                }
+            });
+            
+            // Check the empty assistant turn (turn 3) for any hidden elements
+            const turns = document.querySelectorAll('section[data-testid^="conversation-turn-"]');
+            const lastTurn = turns[turns.length - 1];
+            if (lastTurn) {
+                info.lastTurnHTML = lastTurn.innerHTML.substring(0, 500);
+                info.lastTurnClasses = lastTurn.className;
+                info.lastTurnChildren = Array.from(lastTurn.children).map(c => ({
+                    tag: c.tagName,
+                    className: c.className.substring(0, 50),
+                    text: (c.innerText || '').trim().substring(0, 100),
+                }));
+            }
+            
+            // Check for any toast/notification elements
+            info.toasts = [];
+            document.querySelectorAll('[class*="toast"], [class*="notification"], [class*="snackbar"], [class*="alert"]').forEach(el => {
+                const text = (el.innerText || '').trim();
+                if (text) info.toasts.push(text.substring(0, 200));
+            });
+            
+            // Check network status
+            info.isOnline = navigator.onLine;
+            
+            // Check if there's a stop/cancel button visible (indicating generation)
+            const stopBtn = document.querySelector('button[aria-label="Stop generating"], button[data-testid="stop-button"]');
+            info.hasStopButton = !!stopBtn;
+            
+            return info;
+        }
+    """)
+    
+    print(f"  Online: {errors.get('isOnline')}")
+    print(f"  Error patterns found: {errors.get('errorPatterns', [])}")
+    print(f"  Dialogs: {errors.get('dialogs', [])}")
+    print(f"  Retry buttons: {errors.get('retryButtons', [])}")
+    print(f"  Toasts: {errors.get('toasts', [])}")
+    print(f"  Stop button visible: {errors.get('hasStopButton')}")
+    print(f"  Last turn classes: {errors.get('lastTurnClasses', '')}")
+    print(f"  Last turn children:")
+    for child in errors.get('lastTurnChildren', []):
+        print(f"    <{child['tag']}> class={child['className']} text={child['text'][:60]}")
+    print(f"  Last turn HTML (first 400 chars):")
+    html = errors.get('lastTurnHTML', '')
+    for line in html[:400].split('\n')[:10]:
+        print(f"    {line[:100]}")
+    
+    # 2. Try to navigate to a fresh chat using the new-chat button
+    print(f"\n{'='*60}")
+    print("STEP 2: Navigate to fresh chat via button click")
+    print("="*60)
+    
+    # Find and click new chat button
+    clicked = await page.evaluate("""
+        () => {
+            const selectors = [
+                "a[data-testid='create-new-chat-button']",
+                "a[href='/']",
+                "nav a[href='/']",
+            ];
+            for (const sel of selectors) {
+                const btn = document.querySelector(sel);
+                if (btn) {
+                    btn.click();
+                    return sel;
+                }
+            }
+            return null;
+        }
+    """)
+    print(f"  Clicked: {clicked}")
+    
+    if not clicked:
+        print("  ERROR: Could not find new chat button!")
+        await pw.stop()
+        return
+    
+    # Wait for navigation
+    await asyncio.sleep(3)
+    
+    # Verify fresh chat
+    turn_count = await page.evaluate(
+        "document.querySelectorAll('[data-testid^=\"conversation-turn-\"]').length"
+    )
+    print(f"  Turns after clicking new chat: {turn_count}")
+    print(f"  URL: {page.url}")
+    
+    if turn_count != 0:
+        print("  WARNING: Not a fresh chat!")
+        await pw.stop()
+        return
+    
+    # 3. Wait a moment, then send a message in the fresh chat
+    print(f"\n{'='*60}")
+    print("STEP 3: Send message in fresh chat")
+    print("="*60)
+    
+    await asyncio.sleep(2)
+    
+    # Type message
+    el = page.locator("#prompt-textarea").first
+    await el.click()
+    await asyncio.sleep(0.2)
+    await page.keyboard.type("What is 5+5? Just the number.", delay=10)
+    await asyncio.sleep(0.5)
+    
+    # Check send button
+    state = await page.evaluate("""
+        () => {
+            const sendBtn = document.querySelector("button[data-testid='send-button']");
+            return {
+                exists: !!sendBtn,
+                disabled: sendBtn ? sendBtn.disabled : null,
+                text: sendBtn ? sendBtn.innerText : null,
+            };
+        }
+    """)
+    print(f"  Send button: exists={state['exists']}, disabled={state['disabled']}")
+    
+    if not state['exists'] or state['disabled']:
+        print("  ERROR: Send button not ready!")
+        await pw.stop()
+        return
+    
+    # Click send
+    send_btn = page.locator("button[data-testid='send-button']").first
+    await send_btn.click()
+    print(f"  Send clicked at {time.strftime('%H:%M:%S')}")
+    
+    # Wait for response — poll for up to 30 seconds
+    print(f"  Waiting for response...")
+    for i in range(60):
+        await asyncio.sleep(0.5)
+        result = await page.evaluate("""
+            () => {
+                const turns = document.querySelectorAll('section[data-testid^="conversation-turn-"]');
+                const last = turns[turns.length - 1];
+                if (!last) return { turnCount: 0 };
+                
+                const role = last.getAttribute('data-turn');
+                const text = (last.innerText || '').trim();
+                const copyBtn = last.querySelector('button[data-testid="copy-turn-action-button"], button[aria-label="Copy response"]');
+                
+                return {
+                    turnCount: turns.length,
+                    lastRole: role,
+                    lastTextLen: text.length,
+                    lastText: text.substring(0, 100),
+                    hasCopy: !!copyBtn,
+                };
+            }
+        """)
+        
+        if result['turnCount'] >= 2 and result.get('lastRole') == 'assistant':
+            if result.get('hasCopy') or result.get('lastTextLen', 0) > 0:
+                print(f"  ✓ Response at {time.strftime('%H:%M:%S')} ({(i+1)*0.5:.0f}s)")
+                print(f"    Turns: {result['turnCount']}")
+                print(f"    Text ({result['lastTextLen']} chars): {result.get('lastText', '')[:60]}")
+                print(f"    Copy button: {result.get('hasCopy')}")
+                break
+        
+        if i % 10 == 9:
+            print(f"    ...waiting ({(i+1)*0.5:.0f}s, turns={result['turnCount']}, text={result.get('lastTextLen', 0)} chars)")
+    else:
+        print(f"  ✗ No response after 30s")
+        print(f"    Final state: {result}")
+    
+    # 4. Now send a SECOND message in this fresh chat
+    print(f"\n{'='*60}")
+    print("STEP 4: Send SECOND message (the critical test)")
+    print("="*60)
+    
+    await asyncio.sleep(5)  # 5-second cooldown
+    
+    turn_count_before = await page.evaluate(
+        "document.querySelectorAll('[data-testid^=\"conversation-turn-\"]').length"
+    )
+    print(f"  Turns before: {turn_count_before}")
+    
+    # Type second message
+    el = page.locator("#prompt-textarea").first
+    await el.click()
+    await asyncio.sleep(0.2)
+    await page.keyboard.type("What is 3+3? Just the number.", delay=10)
+    await asyncio.sleep(0.5)
+    
+    # Verify text is in textarea
+    ta_text = await page.evaluate(
+        "document.querySelector('#prompt-textarea')?.innerText?.trim() || ''"
+    )
+    print(f"  Textarea text: {repr(ta_text)}")
+    
+    # Check send button
+    state2 = await page.evaluate("""
+        () => {
+            const sendBtn = document.querySelector("button[data-testid='send-button']");
+            return {
+                exists: !!sendBtn,
+                disabled: sendBtn ? sendBtn.disabled : null,
+            };
+        }
+    """)
+    print(f"  Send button: exists={state2['exists']}, disabled={state2['disabled']}")
+    
+    # Click send
+    send_btn2 = page.locator("button[data-testid='send-button']").first
+    await send_btn2.click()
+    print(f"  Send clicked at {time.strftime('%H:%M:%S')}")
+    
+    # Wait for response
+    print(f"  Waiting for response...")
+    for i in range(60):
+        await asyncio.sleep(0.5)
+        result2 = await page.evaluate("""
+            () => {
+                const turns = document.querySelectorAll('section[data-testid^="conversation-turn-"]');
+                const last = turns[turns.length - 1];
+                if (!last) return { turnCount: 0 };
+                
+                const role = last.getAttribute('data-turn');
+                const text = (last.innerText || '').trim();
+                const copyBtn = last.querySelector('button[data-testid="copy-turn-action-button"], button[aria-label="Copy response"]');
+                
+                return {
+                    turnCount: turns.length,
+                    lastRole: role,
+                    lastTextLen: text.length,
+                    lastText: text.substring(0, 100),
+                    hasCopy: !!copyBtn,
+                };
+            }
+        """)
+        
+        if result2['turnCount'] > turn_count_before and result2.get('lastRole') == 'assistant':
+            if result2.get('hasCopy') or result2.get('lastTextLen', 0) > 0:
+                print(f"  ✓ Response at {time.strftime('%H:%M:%S')} ({(i+1)*0.5:.0f}s)")
+                print(f"    Turns: {result2['turnCount']}")
+                print(f"    Text ({result2['lastTextLen']} chars): {result2.get('lastText', '')[:60]}")
+                print(f"    Copy button: {result2.get('hasCopy')}")
+                break
+        
+        if i % 10 == 9:
+            print(f"    ...waiting ({(i+1)*0.5:.0f}s, turns={result2['turnCount']}, text={result2.get('lastTextLen', 0)} chars)")
+    else:
+        print(f"  ✗ No response after 30s")
+        # Check final page state
+        final = await page.evaluate("""
+            () => {
+                const turns = document.querySelectorAll('section[data-testid^="conversation-turn-"]');
+                return Array.from(turns).map((t, i) => ({
+                    index: i,
+                    role: t.getAttribute('data-turn'),
+                    textLen: (t.innerText || '').trim().length,
+                    text: (t.innerText || '').trim().substring(0, 60),
+                    hasCopy: !!t.querySelector('button[data-testid="copy-turn-action-button"]'),
+                    btnCount: t.querySelectorAll('button').length,
+                }));
+            }
+        """)
+        print(f"  Final page state:")
+        for t in final:
+            print(f"    Turn {t['index']} ({t['role']}): {t['textLen']} chars, copy={t['hasCopy']}, btns={t['btnCount']}")
+            print(f"      Text: {t['text'][:60]}")
+    
+    await pw.stop()
+
+asyncio.run(main())

--- a/scripts/test_codex_cli.py
+++ b/scripts/test_codex_cli.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+"""
+Codex CLI compatibility test suite for POST /v1/responses.
+
+Simulates real Codex CLI usage patterns:
+  1. Simple coding question (streaming)
+  2. Tool-calling: model requests shell command execution
+  3. Multi-turn tool loop: question → function_call → function_call_output → answer
+  4. Tool-calling: model requests apply_patch (file edit)
+  5. Streaming with tool calls — SSE event validation
+  6. Multiple tools defined simultaneously
+  7. tool_choice="none" — tools defined but force text response
+  8. function_call_output with error output
+
+Codex CLI sends:
+  - POST /v1/responses with stream=true
+  - instructions (system prompt with coding agent personality)
+  - tools in flat format: [{"type":"function","name":"shell","parameters":{...}}]
+  - Multi-turn input with function_call and function_call_output items
+  - tool_choice="auto" (default)
+
+Prerequisites:
+  - CatGPT API server running: python -m src.api.server
+  - API_TOKEN must match .env (default: dummy123)
+
+Usage:
+  python scripts/test_codex_cli.py
+  python scripts/test_codex_cli.py --test 1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+import httpx
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+except ImportError:
+    pass
+
+# ── Configuration ───────────────────────────────────────────────
+
+DEFAULT_BASE = "http://localhost:8000"
+API_KEY = os.environ.get("API_TOKEN", "dummy123")
+
+PASSED = 0
+FAILED = 0
+SKIPPED = 0
+ERRORS: list[str] = []
+
+# Codex CLI system prompt (simplified version)
+CODEX_SYSTEM_PROMPT = (
+    "You are a coding assistant running in the user's terminal. "
+    "You can execute shell commands and edit files using the provided tools. "
+    "When the user asks you to do something, use the appropriate tool. "
+    "Always respond concisely."
+)
+
+# Codex CLI tool definitions (flat Responses API format)
+SHELL_TOOL = {
+    "type": "function",
+    "name": "shell",
+    "description": "Execute a shell command on the user's machine. Returns stdout, stderr, and exit code.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "command": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Command and arguments to execute",
+            },
+        },
+        "required": ["command"],
+        "additionalProperties": False,
+    },
+}
+
+APPLY_PATCH_TOOL = {
+    "type": "function",
+    "name": "apply_patch",
+    "description": "Apply a unified diff patch to edit files. Use this to create or modify files.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "patch": {
+                "type": "string",
+                "description": "A unified diff patch string",
+            },
+        },
+        "required": ["patch"],
+        "additionalProperties": False,
+    },
+}
+
+
+# ── Helpers ─────────────────────────────────────────────────────
+
+def separator(title: str) -> None:
+    print(f"\n{'=' * 64}")
+    print(f"  {title}")
+    print(f"{'=' * 64}")
+
+
+def ok(msg: str) -> None:
+    global PASSED
+    PASSED += 1
+    print(f"  ✅ {msg}")
+
+
+def fail(msg: str) -> None:
+    global FAILED
+    FAILED += 1
+    ERRORS.append(msg)
+    print(f"  ❌ {msg}")
+
+
+def assert_eq(label, actual, expected):
+    if actual == expected:
+        ok(f"{label}: {actual!r}")
+    else:
+        fail(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def assert_in(label, value, container):
+    if value in container:
+        ok(f"{label}: {value!r} found")
+    else:
+        fail(f"{label}: {value!r} not in {container!r}")
+
+
+def assert_type(label, value, expected_type):
+    if isinstance(value, expected_type):
+        ok(f"{label}: type is {type(value).__name__}")
+    else:
+        fail(f"{label}: expected {expected_type.__name__}, got {type(value).__name__}")
+
+
+def assert_truthy(label, value):
+    if value:
+        ok(f"{label}")
+    else:
+        fail(f"{label}: value is falsy: {value!r}")
+
+
+def assert_nonempty_string(label, value):
+    if isinstance(value, str) and len(value) > 0:
+        ok(f"{label}: \"{value[:60]}{'...' if len(value) > 60 else ''}\"")
+    else:
+        fail(f"{label}: expected non-empty string, got {value!r}")
+
+
+def parse_sse_events(text: str) -> list[dict]:
+    events = []
+    current_event = None
+    current_data_lines = []
+    for line in text.split("\n"):
+        if line.startswith("event: "):
+            current_event = line[7:].strip()
+        elif line.startswith("data: "):
+            current_data_lines.append(line[6:])
+        elif line == "" and current_event is not None:
+            data_str = "\n".join(current_data_lines)
+            try:
+                data = json.loads(data_str)
+            except json.JSONDecodeError:
+                data = data_str
+            events.append({"event": current_event, "data": data})
+            current_event = None
+            current_data_lines = []
+    if current_event is not None and current_data_lines:
+        data_str = "\n".join(current_data_lines)
+        try:
+            data = json.loads(data_str)
+        except json.JSONDecodeError:
+            data = data_str
+        events.append({"event": current_event, "data": data})
+    return events
+
+
+def post_responses(client: httpx.Client, body: dict, stream: bool = False):
+    if stream:
+        return client.post("/v1/responses", json=body, timeout=300.0)
+    r = client.post("/v1/responses", json=body, timeout=300.0)
+    r.raise_for_status()
+    return r.json()
+
+
+# ── Tests ───────────────────────────────────────────────────────
+
+def test_1_codex_simple_question(client: httpx.Client):
+    """Codex CLI: simple coding question via streaming (no tools needed)."""
+    separator("Test 1: Codex CLI — streaming coding question")
+
+    with client.stream(
+        "POST",
+        "/v1/responses",
+        json={
+            "model": "catgpt-browser",
+            "instructions": CODEX_SYSTEM_PROMPT,
+            "input": "What does the 'ls' command do in Unix? Reply in one sentence.",
+            "tools": [SHELL_TOOL, APPLY_PATCH_TOOL],
+            "tool_choice": "auto",
+            "stream": True,
+        },
+        timeout=300.0,
+    ) as r:
+        r.raise_for_status()
+        body = r.read().decode()
+
+    events = parse_sse_events(body)
+    event_types = [e["event"] for e in events]
+
+    assert_truthy("received SSE events", len(events) > 0)
+    assert_in("has response.created", "response.created", event_types)
+    assert_in("has response.completed", "response.completed", event_types)
+
+    # Should be a text response (not a tool call) since this is a knowledge question
+    completed = next((e["data"] for e in events if e["event"] == "response.completed"), {})
+    resp = completed.get("response", {})
+    assert_eq("status", resp.get("status"), "completed")
+    assert_truthy("output present", len(resp.get("output", [])) > 0)
+
+    output_text = resp.get("output_text", "")
+    assert_nonempty_string("output_text", output_text)
+
+    # Should have tools echoed even if not used
+    assert_truthy("tools echoed", len(resp.get("tools", [])) >= 2)
+
+    print(f"\n  Model replied: \"{output_text[:80]}\"")
+
+
+def test_2_codex_tool_call_shell(client: httpx.Client):
+    """Codex CLI: model should call the shell tool for a system task."""
+    separator("Test 2: Codex CLI — shell tool call")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "instructions": CODEX_SYSTEM_PROMPT,
+        "input": "List the files in the current directory.",
+        "tools": [SHELL_TOOL],
+        "tool_choice": "auto",
+        "stream": False,
+    })
+
+    assert_truthy("id starts with resp_", resp.get("id", "").startswith("resp_"))
+    assert_eq("status", resp.get("status"), "completed")
+
+    output = resp.get("output", [])
+    assert_truthy("output has items", len(output) > 0)
+
+    first = output[0]
+    output_type = first.get("type")
+
+    if output_type == "function_call":
+        assert_eq("function_call.name", first.get("name"), "shell")
+        assert_truthy("function_call.call_id present", first.get("call_id"))
+        assert_eq("function_call.status", first.get("status"), "completed")
+
+        # Parse arguments
+        args = json.loads(first.get("arguments", "{}"))
+        assert_truthy("arguments.command present", "command" in args)
+        assert_type("arguments.command is list", args["command"], list)
+
+        print(f"\n  Model called: shell({args})")
+    else:
+        # Model answered directly — also acceptable
+        ok(f"Model answered directly (type={output_type})")
+        print(f"\n  Model replied: \"{resp.get('output_text', '')[:80]}\"")
+
+
+def test_3_codex_full_tool_loop(client: httpx.Client):
+    """
+    Codex CLI: full tool loop.
+    Turn 1: User asks → model calls shell tool
+    Turn 2: We send function_call_output → model gives final answer
+    """
+    separator("Test 3: Codex CLI — full tool loop (multi-turn)")
+
+    # Turn 1: Ask something that should trigger a shell call
+    resp1 = post_responses(client, {
+        "model": "catgpt-browser",
+        "instructions": CODEX_SYSTEM_PROMPT,
+        "input": "Run 'echo hello' in the shell.",
+        "tools": [SHELL_TOOL],
+        "tool_choice": "auto",
+        "stream": False,
+    })
+
+    assert_truthy("turn 1: id present", resp1.get("id", "").startswith("resp_"))
+    output1 = resp1.get("output", [])
+    assert_truthy("turn 1: output present", len(output1) > 0)
+
+    first = output1[0]
+    if first.get("type") != "function_call":
+        # If model answered directly, that's OK but we can't test the full loop
+        ok("Model answered directly — skipping tool loop test")
+        print(f"\n  Model replied: \"{resp1.get('output_text', '')[:80]}\"")
+        return
+
+    assert_eq("turn 1: function_call.name", first.get("name"), "shell")
+    call_id = first.get("call_id", "")
+    assert_truthy("turn 1: call_id present", call_id)
+    print(f"\n  Turn 1 — Model called: shell()")
+
+    # Turn 2: Send function_call_output with the tool result
+    resp2 = post_responses(client, {
+        "model": "catgpt-browser",
+        "instructions": CODEX_SYSTEM_PROMPT,
+        "input": [
+            {"role": "user", "content": "Run 'echo hello' in the shell."},
+            {
+                "type": "function_call",
+                "name": first.get("name"),
+                "arguments": first.get("arguments", "{}"),
+                "call_id": call_id,
+            },
+            {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": "Exit code: 0\nWall time: 0.1 seconds\nOutput:\nhello\n",
+            },
+        ],
+        "tools": [SHELL_TOOL],
+        "tool_choice": "auto",
+        "stream": False,
+    })
+
+    assert_truthy("turn 2: id present", resp2.get("id", "").startswith("resp_"))
+    assert_eq("turn 2: status", resp2.get("status"), "completed")
+
+    output2 = resp2.get("output", [])
+    assert_truthy("turn 2: output present", len(output2) > 0)
+
+    # Turn 2 should be a text message (the final answer), not another tool call
+    if output2[0].get("type") == "message":
+        ok("turn 2: model responded with text message")
+        assert_nonempty_string("turn 2: output_text", resp2.get("output_text", ""))
+    else:
+        ok(f"turn 2: model responded with {output2[0].get('type')}")
+
+    print(f"\n  Turn 2 — Model replied: \"{resp2.get('output_text', '')[:80]}\"")
+
+
+def test_4_codex_apply_patch_tool(client: httpx.Client):
+    """Codex CLI: model calls apply_patch to edit a file."""
+    separator("Test 4: Codex CLI — apply_patch tool call")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "instructions": CODEX_SYSTEM_PROMPT,
+        "input": "Create a file called hello.py that prints 'Hello, World!'",
+        "tools": [SHELL_TOOL, APPLY_PATCH_TOOL],
+        "tool_choice": "auto",
+        "stream": False,
+    })
+
+    assert_truthy("id present", resp.get("id", "").startswith("resp_"))
+    output = resp.get("output", [])
+    assert_truthy("output present", len(output) > 0)
+
+    first = output[0]
+    if first.get("type") == "function_call":
+        name = first.get("name", "")
+        assert_in("tool called", name, ["apply_patch", "shell"])
+        assert_truthy("call_id present", first.get("call_id"))
+        assert_nonempty_string("arguments", first.get("arguments", ""))
+        print(f"\n  Model called: {name}({first.get('arguments', '')[:80]}...)")
+    else:
+        ok("Model answered directly")
+        print(f"\n  Model replied: \"{resp.get('output_text', '')[:80]}\"")
+
+
+def test_5_codex_streaming_tool_call(client: httpx.Client):
+    """Codex CLI: streaming SSE events for a tool call response."""
+    separator("Test 5: Codex CLI — streaming tool call SSE")
+
+    with client.stream(
+        "POST",
+        "/v1/responses",
+        json={
+            "model": "catgpt-browser",
+            "instructions": CODEX_SYSTEM_PROMPT,
+            "input": "Check what version of python is installed. Use the shell tool.",
+            "tools": [SHELL_TOOL],
+            "tool_choice": "auto",
+            "stream": True,
+        },
+        timeout=300.0,
+    ) as r:
+        r.raise_for_status()
+        body = r.read().decode()
+
+    events = parse_sse_events(body)
+    event_types = [e["event"] for e in events]
+
+    assert_truthy("received SSE events", len(events) > 0)
+    assert_in("has response.created", "response.created", event_types)
+    assert_in("has response.completed", "response.completed", event_types)
+
+    # Check if it's a tool call or text response
+    completed = next((e["data"] for e in events if e["event"] == "response.completed"), {})
+    resp = completed.get("response", {})
+    output = resp.get("output", [])
+
+    if output and output[0].get("type") == "function_call":
+        # Validate tool call SSE events
+        assert_in("has output_item.added", "response.output_item.added", event_types)
+        assert_in("has output_item.done", "response.output_item.done", event_types)
+
+        # Should have function_call_arguments events
+        if "response.function_call_arguments.delta" in event_types:
+            ok("has function_call_arguments.delta")
+            delta = next(
+                (e["data"] for e in events
+                 if e["event"] == "response.function_call_arguments.delta"), {}
+            )
+            assert_nonempty_string("delta content", delta.get("delta", ""))
+
+        if "response.function_call_arguments.done" in event_types:
+            ok("has function_call_arguments.done")
+            done = next(
+                (e["data"] for e in events
+                 if e["event"] == "response.function_call_arguments.done"), {}
+            )
+            assert_eq("done.name", done.get("name"), "shell")
+            assert_nonempty_string("done.arguments", done.get("arguments", ""))
+
+        fc = output[0]
+        print(f"\n  Model called: {fc.get('name')}() via streaming")
+    else:
+        ok("Model answered with text (no tool call)")
+        print(f"\n  Model replied: \"{resp.get('output_text', '')[:80]}\"")
+
+
+def test_6_codex_multiple_tools(client: httpx.Client):
+    """Codex CLI: both shell and apply_patch tools available."""
+    separator("Test 6: Codex CLI — multiple tools defined")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "instructions": CODEX_SYSTEM_PROMPT,
+        "input": "What is 2+2? Just answer directly, no tools needed.",
+        "tools": [SHELL_TOOL, APPLY_PATCH_TOOL],
+        "tool_choice": "auto",
+        "stream": False,
+    })
+
+    assert_truthy("id present", resp.get("id", "").startswith("resp_"))
+    assert_eq("status", resp.get("status"), "completed")
+
+    # Should answer directly without using tools
+    output = resp.get("output", [])
+    assert_truthy("output present", len(output) > 0)
+
+    # Both tools should be echoed
+    tools = resp.get("tools", [])
+    assert_truthy("both tools echoed", len(tools) >= 2)
+    tool_names = {t.get("name") for t in tools}
+    assert_in("shell in tools", "shell", tool_names)
+    assert_in("apply_patch in tools", "apply_patch", tool_names)
+
+    output_text = resp.get("output_text", "")
+    assert_nonempty_string("output_text", output_text)
+    print(f"\n  Model replied: \"{output_text}\"")
+
+
+def test_7_codex_tool_choice_none(client: httpx.Client):
+    """Codex CLI: tool_choice=none forces text response even with tools defined."""
+    separator("Test 7: Codex CLI — tool_choice=none")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "instructions": CODEX_SYSTEM_PROMPT,
+        "input": "List files in /tmp. Describe what command you would use.",
+        "tools": [SHELL_TOOL],
+        "tool_choice": "none",
+        "stream": False,
+    })
+
+    assert_truthy("id present", resp.get("id", "").startswith("resp_"))
+    assert_eq("status", resp.get("status"), "completed")
+
+    output = resp.get("output", [])
+    assert_truthy("output present", len(output) > 0)
+
+    # With tool_choice=none, should always be a text message
+    first = output[0]
+    assert_eq("output type is message", first.get("type"), "message")
+    assert_nonempty_string("output_text", resp.get("output_text", ""))
+
+    print(f"\n  Model replied: \"{resp.get('output_text', '')[:80]}\"")
+
+
+def test_8_codex_error_tool_output(client: httpx.Client):
+    """Codex CLI: function_call_output with error — model should handle gracefully."""
+    separator("Test 8: Codex CLI — tool output with error")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "instructions": CODEX_SYSTEM_PROMPT,
+        "input": [
+            {"role": "user", "content": "Check disk space on the machine."},
+            {
+                "type": "function_call",
+                "name": "shell",
+                "arguments": json.dumps({"command": ["df", "-h"]}),
+                "call_id": "call_test_error_001",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_test_error_001",
+                "output": "Exit code: 127\nWall time: 0.0 seconds\nOutput:\ndf: command not found\n",
+            },
+        ],
+        "tools": [SHELL_TOOL],
+        "tool_choice": "auto",
+        "stream": False,
+    })
+
+    assert_truthy("id present", resp.get("id", "").startswith("resp_"))
+    assert_eq("status", resp.get("status"), "completed")
+
+    output = resp.get("output", [])
+    assert_truthy("output present", len(output) > 0)
+
+    # Model should respond with text explaining the error, or try another tool
+    output_type = output[0].get("type")
+    assert_in("output type", output_type, ["message", "function_call"])
+
+    if output_type == "message":
+        assert_nonempty_string("output_text", resp.get("output_text", ""))
+        print(f"\n  Model replied: \"{resp.get('output_text', '')[:80]}\"")
+    else:
+        print(f"\n  Model called: {output[0].get('name')}() — trying alternative")
+
+
+# ── Main ────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Codex CLI /v1/responses tests")
+    parser.add_argument("--base-url", default=DEFAULT_BASE, help="API base URL")
+    parser.add_argument("--test", type=int, help="Run a specific test number (1-8)")
+    parser.add_argument("--api-key", default=API_KEY, help="API bearer token")
+    args = parser.parse_args()
+
+    base_url = args.base_url.rstrip("/")
+    client = httpx.Client(
+        base_url=base_url,
+        headers={"Authorization": f"Bearer {args.api_key}"},
+        timeout=httpx.Timeout(300.0, connect=10.0),
+    )
+
+    ALL_TESTS = [
+        (1, test_1_codex_simple_question),
+        (2, test_2_codex_tool_call_shell),
+        (3, test_3_codex_full_tool_loop),
+        (4, test_4_codex_apply_patch_tool),
+        (5, test_5_codex_streaming_tool_call),
+        (6, test_6_codex_multiple_tools),
+        (7, test_7_codex_tool_choice_none),
+        (8, test_8_codex_error_tool_output),
+    ]
+
+    BROWSER_TESTS = {1, 2, 3, 4, 5, 6, 7, 8}
+
+    print("\n" + "=" * 64)
+    print("  CatGPT Gateway — Codex CLI Compatibility Test Suite")
+    print("=" * 64)
+    print(f"  Base URL : {base_url}")
+    print(f"  Auth     : Bearer {args.api_key[:4]}{'*' * (len(args.api_key) - 4)}")
+
+    # Check server reachability
+    try:
+        r = client.get("/v1/models", timeout=10.0)
+        if r.status_code == 200:
+            print(f"  Server   : OK")
+        else:
+            print(f"\n  ⚠️  /v1/models returned {r.status_code}")
+    except httpx.ConnectError:
+        print(f"\n  ❌ Cannot connect to {base_url}")
+        sys.exit(1)
+
+    start_time = time.time()
+    last_was_browser = False
+
+    for num, test_fn in ALL_TESTS:
+        if args.test is not None and num != args.test:
+            continue
+
+        is_browser = num in BROWSER_TESTS
+        if is_browser and last_was_browser:
+            print("\n  ⏳ Waiting 5s between browser tests...")
+            time.sleep(5)
+
+        try:
+            test_fn(client)
+        except httpx.HTTPStatusError as e:
+            try:
+                body = e.response.text
+            except httpx.ResponseNotRead:
+                body = "(streaming response not read)"
+            fail(f"Test {num} HTTP error: {e.response.status_code} — {body[:200]}")
+        except (httpx.ReadTimeout, httpx.ConnectTimeout) as e:
+            fail(f"Test {num} timeout: {e}")
+        except Exception as e:
+            fail(f"Test {num} exception: {e}")
+            traceback.print_exc()
+
+        last_was_browser = is_browser
+
+    client.close()
+    elapsed = time.time() - start_time
+
+    print(f"\n{'=' * 64}")
+    print(f"  RESULTS: {PASSED} passed, {FAILED} failed, {SKIPPED} skipped")
+    print(f"  Time: {elapsed:.1f}s")
+    print(f"{'=' * 64}")
+
+    if ERRORS:
+        print("\n  Failures:")
+        for err in ERRORS:
+            print(f"    • {err}")
+
+    print()
+    sys.exit(1 if FAILED > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_console_errors.py
+++ b/scripts/test_console_errors.py
@@ -1,0 +1,215 @@
+"""
+Capture JavaScript console errors while sending messages.
+This will reveal WHY ChatGPT's frontend fails to send the 2nd message.
+"""
+import asyncio, sys, time
+sys.path.insert(0, ".")
+from patchright.async_api import async_playwright
+
+# Collect console messages
+console_msgs = []
+
+async def main():
+    pw = await async_playwright().start()
+    browser = await pw.chromium.connect_over_cdp("http://127.0.0.1:9222")
+    page = [p for p in browser.contexts[0].pages if "chatgpt.com" in p.url][0]
+    
+    # Listen for console errors and warnings
+    def on_console(msg):
+        if msg.type in ("error", "warning"):
+            console_msgs.append({
+                "time": time.strftime("%H:%M:%S"),
+                "type": msg.type,
+                "text": msg.text[:300],
+            })
+    
+    # Listen for page errors (uncaught exceptions)
+    def on_pageerror(error):
+        console_msgs.append({
+            "time": time.strftime("%H:%M:%S"),
+            "type": "PAGE_ERROR",
+            "text": str(error)[:500],
+        })
+    
+    page.on("console", on_console)
+    page.on("pageerror", on_pageerror)
+    
+    # Navigate to fresh chat
+    print("Navigating to fresh chat...")
+    console_msgs.clear()
+    await page.evaluate("""
+        () => { document.querySelector("a[data-testid='create-new-chat-button']")?.click(); }
+    """)
+    await asyncio.sleep(3)
+    
+    turns = await page.evaluate(
+        "document.querySelectorAll('[data-testid^=\"conversation-turn-\"]').length"
+    )
+    print(f"Fresh chat: {turns} turns")
+    
+    if console_msgs:
+        print(f"\nConsole messages during navigation:")
+        for m in console_msgs:
+            print(f"  [{m['time']}] {m['type']}: {m['text'][:120]}")
+    
+    # --- Message 1 ---
+    print(f"\n{'='*60}")
+    print("MESSAGE 1")
+    print(f"{'='*60}")
+    console_msgs.clear()
+    
+    el = page.locator("#prompt-textarea").first
+    await el.click()
+    await asyncio.sleep(0.2)
+    await page.keyboard.insert_text("What is 1+1? Reply with just the number.")
+    await asyncio.sleep(0.3)
+    
+    # Try ENTER instead of clicking send button
+    print("  Sending via Enter key...")
+    await page.keyboard.press("Enter")
+    t0 = time.time()
+    
+    # Wait for response
+    for i in range(40):
+        await asyncio.sleep(0.5)
+        r = await page.evaluate("""
+            () => {
+                const turns = document.querySelectorAll('section[data-testid^="conversation-turn-"]');
+                const last = turns[turns.length - 1];
+                if (!last) return { count: 0 };
+                return {
+                    count: turns.length,
+                    role: last.getAttribute('data-turn'),
+                    text: (last.innerText || '').trim().substring(0, 100),
+                    textLen: (last.innerText || '').trim().length,
+                    hasCopy: !!last.querySelector('button[data-testid="copy-turn-action-button"]'),
+                };
+            }
+        """)
+        if r.get('hasCopy') and r.get('role') == 'assistant' and r.get('textLen', 0) > 0:
+            print(f"  ✓ Response in {time.time()-t0:.1f}s: '{r['text'][:50]}'")
+            break
+        if i % 10 == 9:
+            print(f"    ...waiting ({(i+1)*0.5:.0f}s, turns={r['count']}, text={r.get('textLen',0)} chars)")
+    else:
+        print(f"  ✗ No response after 20s")
+        if console_msgs:
+            print(f"\n  Console errors during message 1:")
+            for m in console_msgs:
+                print(f"    [{m['time']}] {m['type']}: {m['text'][:150]}")
+        await pw.stop()
+        return
+    
+    if console_msgs:
+        print(f"\n  Console messages during message 1:")
+        for m in console_msgs:
+            print(f"    [{m['time']}] {m['type']}: {m['text'][:150]}")
+    
+    # --- Message 2 (with 10s cooldown) ---
+    print(f"\n{'='*60}")
+    print("MESSAGE 2 (10s cooldown)")
+    print(f"{'='*60}")
+    
+    await asyncio.sleep(10)
+    console_msgs.clear()
+    
+    # Check current state
+    pre = await page.evaluate("""
+        () => {
+            const turns = document.querySelectorAll('section[data-testid^="conversation-turn-"]');
+            const ta = document.querySelector('#prompt-textarea');
+            return {
+                turnCount: turns.length,
+                textareaExists: !!ta,
+                textareaFocusable: ta ? ta.getAttribute('contenteditable') : null,
+                url: window.location.href,
+            };
+        }
+    """)
+    print(f"  Pre-state: {pre}")
+    
+    el2 = page.locator("#prompt-textarea").first
+    await el2.click()
+    await asyncio.sleep(0.2)
+    await page.keyboard.insert_text("What is 2+2? Reply with just the number.")
+    await asyncio.sleep(0.3)
+    
+    # Verify text
+    ta_text = await page.evaluate(
+        "document.querySelector('#prompt-textarea')?.innerText?.trim() || ''"
+    )
+    print(f"  Textarea text: {repr(ta_text[:60])}")
+    
+    # Check send button state  
+    btn_state = await page.evaluate("""
+        () => {
+            const btn = document.querySelector("button[data-testid='send-button']");
+            if (!btn) return { exists: false };
+            return { 
+                exists: true, 
+                disabled: btn.disabled,
+                ariaDisabled: btn.getAttribute('aria-disabled'),
+                visible: btn.offsetParent !== null,
+                rect: btn.getBoundingClientRect(),
+            };
+        }
+    """)
+    print(f"  Send button: {btn_state}")
+    
+    if console_msgs:
+        print(f"\n  Console errors BEFORE send:")
+        for m in console_msgs:
+            print(f"    [{m['time']}] {m['type']}: {m['text'][:150]}")
+    
+    console_msgs.clear()
+    
+    # Send via Enter key
+    print("  Sending via Enter key...")
+    await page.keyboard.press("Enter")
+    t0 = time.time()
+    
+    # Check console immediately
+    await asyncio.sleep(1)
+    if console_msgs:
+        print(f"\n  Console errors IMMEDIATELY after send:")
+        for m in console_msgs:
+            print(f"    [{m['time']}] {m['type']}: {m['text'][:200]}")
+    
+    # Wait for response
+    for i in range(60):
+        await asyncio.sleep(0.5)
+        r = await page.evaluate("""
+            () => {
+                const turns = document.querySelectorAll('section[data-testid^="conversation-turn-"]');
+                const last = turns[turns.length - 1];
+                if (!last) return { count: 0 };
+                return {
+                    count: turns.length,
+                    role: last.getAttribute('data-turn'),
+                    text: (last.innerText || '').trim().substring(0, 100),
+                    textLen: (last.innerText || '').trim().length,
+                    hasCopy: !!last.querySelector('button[data-testid="copy-turn-action-button"]'),
+                };
+            }
+        """)
+        if r.get('hasCopy') and r.get('role') == 'assistant' and r.get('textLen', 0) > 0:
+            print(f"  ✓ Response in {time.time()-t0:.1f}s: '{r['text'][:50]}'")
+            break
+        if i % 10 == 9:
+            print(f"    ...waiting ({(i+1)*0.5:.0f}s, turns={r['count']}, text={r.get('textLen',0)} chars)")
+            if console_msgs:
+                print(f"    Console errors so far:")
+                for m in console_msgs[-5:]:
+                    print(f"      [{m['time']}] {m['type']}: {m['text'][:150]}")
+    else:
+        print(f"  ✗ No response after 30s")
+    
+    print(f"\n{'='*60}")
+    print(f"ALL CONSOLE MESSAGES ({len(console_msgs)} total)")
+    print(f"{'='*60}")
+    for m in console_msgs:
+        print(f"  [{m['time']}] {m['type']}: {m['text'][:200]}")
+    
+    await pw.stop()
+
+asyncio.run(main())

--- a/scripts/test_input_methods.py
+++ b/scripts/test_input_methods.py
@@ -1,0 +1,398 @@
+"""
+Standalone test: which input method properly triggers React state in ChatGPT?
+
+This script connects to the running browser, sends message 1 normally,
+then tests different input methods for message 2 to find which one
+causes ChatGPT's backend API call to fire.
+
+Run AFTER the server is started (browser is open and logged in).
+Usage: .venv/bin/python scripts/test_input_methods.py
+"""
+
+import asyncio
+import sys
+import time
+
+# Add project root to path
+sys.path.insert(0, ".")
+
+from patchright.async_api import async_playwright
+
+
+INPUT_SELECTOR = "#prompt-textarea"
+SEND_BUTTON = "button[data-testid='send-button']"
+
+
+async def connect_to_browser():
+    """Connect to the already-running browser via CDP."""
+    pw = await async_playwright().start()
+    try:
+        browser = await pw.chromium.connect_over_cdp("http://127.0.0.1:9222")
+    except Exception:
+        print("ERROR: Can't connect to browser. Make sure server is running.")
+        print("The browser must be launched with --remote-debugging-port=9222")
+        await pw.stop()
+        return None, None, None
+    
+    contexts = browser.contexts
+    if not contexts:
+        print("ERROR: No browser contexts found")
+        return None, None, None
+    
+    pages = contexts[0].pages
+    chatgpt_page = None
+    for p in pages:
+        if "chatgpt.com" in p.url:
+            chatgpt_page = p
+            break
+    
+    if not chatgpt_page:
+        print(f"ERROR: No ChatGPT page found. Pages: {[p.url for p in pages]}")
+        return None, None, None
+    
+    print(f"Connected to: {chatgpt_page.url}")
+    return pw, browser, chatgpt_page
+
+
+async def check_textarea_state(page) -> dict:
+    """Check the current state of the textarea and send button."""
+    return await page.evaluate("""
+        () => {
+            const ta = document.querySelector('#prompt-textarea');
+            const sendBtn = document.querySelector("button[data-testid='send-button']");
+            
+            return {
+                textareaExists: !!ta,
+                textareaText: ta ? ta.innerText.trim() : null,
+                textareaHTML: ta ? ta.innerHTML.substring(0, 200) : null,
+                sendBtnExists: !!sendBtn,
+                sendBtnDisabled: sendBtn ? sendBtn.disabled : null,
+                sendBtnAriaDisabled: sendBtn ? sendBtn.getAttribute('aria-disabled') : null,
+                sendBtnClassName: sendBtn ? sendBtn.className.substring(0, 100) : null,
+            };
+        }
+    """)
+
+
+async def wait_for_network_call(page, timeout=15):
+    """Wait for a backend-api/conversation POST and return True if seen."""
+    seen = {"called": False}
+    
+    def on_request(req):
+        if "backend-api/conversation" in req.url and req.method == "POST":
+            seen["called"] = True
+            print(f"  ✓ NETWORK: {req.method} {req.url[:80]}")
+    
+    page.on("request", on_request)
+    
+    start = time.time()
+    while not seen["called"] and (time.time() - start) < timeout:
+        await asyncio.sleep(0.5)
+    
+    page.remove_listener("request", on_request)
+    return seen["called"]
+
+
+async def count_turns(page) -> int:
+    return await page.evaluate(
+        "document.querySelectorAll('[data-testid^=\"conversation-turn-\"]').length"
+    )
+
+
+async def method_keyboard_type(page, text):
+    """Method 1: keyboard.type() — sends keyDown/keyPress/keyUp per char."""
+    el = page.locator(INPUT_SELECTOR).first
+    await el.click()
+    await asyncio.sleep(0.1)
+    # Select all and delete
+    mod = "Meta" if sys.platform == "darwin" else "Control"
+    await page.keyboard.press(f"{mod}+a")
+    await page.keyboard.press("Backspace")
+    await asyncio.sleep(0.1)
+    await page.keyboard.type(text, delay=5)
+
+
+async def method_clipboard_paste(page, text):
+    """Method 2: Set clipboard and paste via Cmd+V."""
+    el = page.locator(INPUT_SELECTOR).first
+    await el.click()
+    await asyncio.sleep(0.1)
+    mod = "Meta" if sys.platform == "darwin" else "Control"
+    await page.keyboard.press(f"{mod}+a")
+    await page.keyboard.press("Backspace")
+    await asyncio.sleep(0.1)
+    
+    # Set clipboard via page.evaluate and paste
+    await page.evaluate(f"navigator.clipboard.writeText({repr(text)})")
+    await asyncio.sleep(0.1)
+    await page.keyboard.press(f"{mod}+v")
+
+
+async def method_fill(page, text):
+    """Method 3: Playwright's fill() — uses CDP Input.insertText."""
+    el = page.locator(INPUT_SELECTOR).first
+    await el.fill(text)
+
+
+async def method_dispatch_input_event(page, text):
+    """Method 4: Set innerHTML + dispatch input event."""
+    await page.evaluate("""
+        (text) => {
+            const ta = document.querySelector('#prompt-textarea');
+            if (!ta) return;
+            
+            // Focus
+            ta.focus();
+            
+            // Clear
+            ta.innerHTML = '';
+            
+            // Create a paragraph with the text (ChatGPT uses <p> inside contenteditable)
+            const p = document.createElement('p');
+            p.textContent = text;
+            ta.appendChild(p);
+            
+            // Dispatch events that React listens for
+            ta.dispatchEvent(new Event('input', { bubbles: true }));
+            ta.dispatchEvent(new Event('change', { bubbles: true }));
+            
+            // Also try the newer InputEvent
+            ta.dispatchEvent(new InputEvent('input', {
+                bubbles: true,
+                cancelable: true,
+                inputType: 'insertText',
+                data: text,
+            }));
+        }
+    """, text)
+
+
+async def method_exec_command(page, text):
+    """Method 5: document.execCommand('insertText') — fires proper input events."""
+    el = page.locator(INPUT_SELECTOR).first
+    await el.click()
+    await asyncio.sleep(0.1)
+    mod = "Meta" if sys.platform == "darwin" else "Control"
+    await page.keyboard.press(f"{mod}+a")
+    await asyncio.sleep(0.05)
+    
+    await page.evaluate("""
+        (text) => {
+            document.execCommand('insertText', false, text);
+        }
+    """, text)
+
+
+async def method_react_native_setter(page, text):
+    """Method 6: Use React's internal value setter to update state."""
+    await page.evaluate("""
+        (text) => {
+            const ta = document.querySelector('#prompt-textarea');
+            if (!ta) return;
+            ta.focus();
+            
+            // Clear existing content
+            ta.innerHTML = '<p>' + text + '</p>';
+            
+            // Find React fiber and trigger onChange
+            const key = Object.keys(ta).find(k => k.startsWith('__reactFiber$') || k.startsWith('__reactInternalInstance$'));
+            if (key) {
+                let fiber = ta[key];
+                // Walk up to find the component with onChange
+                while (fiber) {
+                    if (fiber.memoizedProps && fiber.memoizedProps.onChange) {
+                        fiber.memoizedProps.onChange({ target: ta });
+                        break;
+                    }
+                    if (fiber.pendingProps && fiber.pendingProps.onChange) {
+                        fiber.pendingProps.onChange({ target: ta });
+                        break;
+                    }
+                    fiber = fiber.return;
+                }
+            }
+            
+            // Also dispatch standard events
+            ta.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+    """, text)
+
+
+async def test_method(page, name, method_fn, text):
+    """Test a single input method: type text, check state, click send, check network."""
+    print(f"\n{'='*60}")
+    print(f"Testing: {name}")
+    print(f"{'='*60}")
+    
+    # Check pre-state
+    pre_turns = await count_turns(page)
+    print(f"  Turns before: {pre_turns}")
+    
+    # Apply input method
+    try:
+        await method_fn(page, text)
+    except Exception as e:
+        print(f"  ✗ Input method FAILED: {e}")
+        return False
+    
+    await asyncio.sleep(0.5)
+    
+    # Check textarea state after input
+    state = await check_textarea_state(page)
+    print(f"  Textarea text: {repr(state.get('textareaText', '')[:80])}")
+    print(f"  Send button exists: {state.get('sendBtnExists')}")
+    print(f"  Send button disabled: {state.get('sendBtnDisabled')}")
+    print(f"  Send button aria-disabled: {state.get('sendBtnAriaDisabled')}")
+    
+    if not state.get("sendBtnExists"):
+        print("  ✗ No send button found — input didn't activate it")
+        return False
+    
+    if state.get("sendBtnDisabled"):
+        print("  ✗ Send button is DISABLED — React didn't register the text")
+        return False
+    
+    print(f"  → Send button is ENABLED — React registered the input!")
+    
+    # Click send and watch for network
+    print(f"  Clicking send...")
+    try:
+        send_btn = page.locator(SEND_BUTTON).first
+        await send_btn.click()
+    except Exception as e:
+        print(f"  ✗ Click send failed: {e}")
+        return False
+    
+    # Wait for network call
+    print(f"  Waiting for backend API call...")
+    got_network = await wait_for_network_call(page, timeout=10)
+    
+    if got_network:
+        print(f"  ✓ SUCCESS — Backend API call detected!")
+        # Wait for response
+        await asyncio.sleep(8)
+        post_turns = await count_turns(page)
+        print(f"  Turns after: {post_turns}")
+        return True
+    else:
+        print(f"  ✗ FAILED — No backend API call after 10s")
+        post_turns = await count_turns(page)
+        print(f"  Turns after: {post_turns}")
+        return False
+
+
+async def main():
+    pw, browser, page = await connect_to_browser()
+    if not page:
+        return
+    
+    try:
+        # First, send message 1 to get into a multi-turn state
+        turns = await count_turns(page)
+        print(f"\nCurrent turns on page: {turns}")
+        
+        if turns == 0:
+            print("\n--- Sending initial message to establish conversation ---")
+            await method_keyboard_type(page, "Say just the word 'hello'")
+            await asyncio.sleep(0.5)
+            state = await check_textarea_state(page)
+            print(f"Send button state: disabled={state.get('sendBtnDisabled')}")
+            
+            send_btn = page.locator(SEND_BUTTON).first
+            await send_btn.click()
+            print("Sent. Waiting for response...")
+            
+            # Wait for assistant response
+            for _ in range(30):
+                await asyncio.sleep(1)
+                turns = await count_turns(page)
+                if turns >= 2:  # user + assistant
+                    break
+            
+            print(f"Turns after first message: {turns}")
+            await asyncio.sleep(3)  # cooldown
+        
+        print("\n" + "="*60)
+        print("NOW TESTING INPUT METHODS FOR THE SECOND MESSAGE")
+        print("="*60)
+        
+        # Test each method one at a time
+        methods = [
+            ("keyboard.type()", method_keyboard_type),
+            ("clipboard paste (Cmd+V)", method_clipboard_paste),
+            ("fill()", method_fill),
+            ("execCommand('insertText')", method_exec_command),
+            ("dispatch input event", method_dispatch_input_event),
+            ("React native setter", method_react_native_setter),
+        ]
+        
+        # Just test what the textarea state looks like after each method
+        # WITHOUT clicking send (so we can test multiple methods)
+        print("\n--- Testing which methods activate the send button ---\n")
+        
+        for name, method_fn in methods:
+            try:
+                # Clear textarea first
+                el = page.locator(INPUT_SELECTOR).first
+                await el.click()
+                await asyncio.sleep(0.1)
+                mod = "Meta" if sys.platform == "darwin" else "Control"
+                await page.keyboard.press(f"{mod}+a")
+                await page.keyboard.press("Backspace")
+                await asyncio.sleep(0.3)
+                
+                # Apply method
+                await method_fn(page, f"Test from {name}")
+                await asyncio.sleep(0.5)
+                
+                # Check state
+                state = await check_textarea_state(page)
+                text = state.get("textareaText", "")
+                disabled = state.get("sendBtnDisabled")
+                exists = state.get("sendBtnExists")
+                
+                status = "✓ ENABLED" if (exists and not disabled) else "✗ DISABLED/MISSING"
+                print(f"  {status} | {name}")
+                print(f"         textarea: {repr(text[:60])}")
+                if not exists:
+                    print(f"         (send button not found)")
+                
+            except Exception as e:
+                print(f"  ✗ ERROR  | {name}: {e}")
+        
+        # Now do the actual send test with the FIRST method that works
+        print("\n--- Finding first method that activates send button ---")
+        
+        for name, method_fn in methods:
+            try:
+                el = page.locator(INPUT_SELECTOR).first
+                await el.click()
+                await asyncio.sleep(0.1)
+                mod = "Meta" if sys.platform == "darwin" else "Control"
+                await page.keyboard.press(f"{mod}+a")
+                await page.keyboard.press("Backspace")
+                await asyncio.sleep(0.3)
+                
+                await method_fn(page, "What is 2+2? Just the number.")
+                await asyncio.sleep(0.5)
+                
+                state = await check_textarea_state(page)
+                if state.get("sendBtnExists") and not state.get("sendBtnDisabled"):
+                    print(f"\n  → Using {name} for the actual send test")
+                    result = await test_method(page, name, method_fn, "What is 2+2? Just the number.")
+                    if result:
+                        print(f"\n{'='*60}")
+                        print(f"WINNER: {name}")
+                        print(f"{'='*60}")
+                    break
+            except Exception:
+                continue
+    
+    finally:
+        # Don't close — the server still needs the browser
+        if pw:
+            await pw.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test_insert_text.py
+++ b/scripts/test_insert_text.py
@@ -1,0 +1,116 @@
+"""
+Test with the ORIGINAL insert_text approach.
+Navigate to fresh chat, send 2 messages, check if both get responses.
+"""
+import asyncio, sys, time
+sys.path.insert(0, ".")
+from patchright.async_api import async_playwright
+
+async def main():
+    pw = await async_playwright().start()
+    browser = await pw.chromium.connect_over_cdp("http://127.0.0.1:9222")
+    page = [p for p in browser.contexts[0].pages if "chatgpt.com" in p.url][0]
+    
+    # Navigate to fresh chat
+    print("Navigating to fresh chat...")
+    await page.evaluate("""
+        () => {
+            const btn = document.querySelector("a[data-testid='create-new-chat-button']");
+            if (btn) btn.click();
+        }
+    """)
+    await asyncio.sleep(3)
+    
+    turns = await page.evaluate(
+        "document.querySelectorAll('[data-testid^=\"conversation-turn-\"]').length"
+    )
+    print(f"Fresh chat: {turns} turns, URL: {page.url}")
+    
+    async def send_and_wait(msg, msg_num, delay_before=0):
+        if delay_before > 0:
+            print(f"\n  Cooldown: {delay_before}s...")
+            await asyncio.sleep(delay_before)
+        
+        print(f"\n--- Message {msg_num}: '{msg}' ---")
+        
+        # Click textarea and use insert_text (the ORIGINAL method)
+        el = page.locator("#prompt-textarea").first
+        await el.click()
+        await asyncio.sleep(0.2)
+        await page.keyboard.insert_text(msg)
+        await asyncio.sleep(0.3)
+        
+        # Verify text and send button
+        state = await page.evaluate("""
+            () => {
+                const ta = document.querySelector('#prompt-textarea');
+                const btn = document.querySelector("button[data-testid='send-button']");
+                return {
+                    text: ta ? ta.innerText.trim() : '',
+                    btnExists: !!btn,
+                    btnDisabled: btn ? btn.disabled : null,
+                };
+            }
+        """)
+        print(f"  Text: {repr(state['text'][:50])}")
+        print(f"  Send: exists={state['btnExists']}, disabled={state['btnDisabled']}")
+        
+        # Click send
+        send = page.locator("button[data-testid='send-button']").first
+        await send.click()
+        t0 = time.time()
+        print(f"  Sent at {time.strftime('%H:%M:%S')}")
+        
+        # Wait for response
+        for i in range(60):
+            await asyncio.sleep(0.5)
+            r = await page.evaluate("""
+                () => {
+                    const turns = document.querySelectorAll('section[data-testid^="conversation-turn-"]');
+                    const last = turns[turns.length - 1];
+                    if (!last) return { count: 0 };
+                    return {
+                        count: turns.length,
+                        role: last.getAttribute('data-turn'),
+                        text: (last.innerText || '').trim().substring(0, 100),
+                        textLen: (last.innerText || '').trim().length,
+                        hasCopy: !!last.querySelector('button[data-testid="copy-turn-action-button"], button[aria-label="Copy response"]'),
+                    };
+                }
+            """)
+            
+            if r['count'] >= msg_num * 2 and r.get('role') == 'assistant' and r.get('textLen', 0) > 0:
+                elapsed = time.time() - t0
+                print(f"  ✓ Response in {elapsed:.1f}s: '{r['text'][:50]}' (copy={r['hasCopy']})")
+                return True
+            
+            if i % 10 == 9:
+                print(f"    ...waiting ({(i+1)*0.5:.0f}s, turns={r['count']}, text={r.get('textLen',0)} chars)")
+        
+        print(f"  ✗ No response after 30s")
+        return False
+    
+    # Message 1
+    ok1 = await send_and_wait("What is 1+1? Just the number.", 1)
+    if not ok1:
+        print("\nMessage 1 failed — something fundamentally broken")
+        await pw.stop()
+        return
+    
+    # Message 2 with various cooldowns
+    ok2 = await send_and_wait("What is 2+2? Just the number.", 2, delay_before=10)
+    
+    if ok2:
+        print(f"\n{'='*60}")
+        print("SUCCESS: Both messages got responses!")
+        print(f"{'='*60}")
+    else:
+        print(f"\n{'='*60}")
+        print("FAILED: Second message got no response (same as before)")
+        print("This confirms the issue is NOT the input method.")
+        print("ChatGPT's backend refuses to generate for the 2nd message.")
+        print(f"{'='*60}")
+    
+    await pw.stop()
+
+asyncio.run(main())

--- a/scripts/test_responses_api.py
+++ b/scripts/test_responses_api.py
@@ -1,0 +1,720 @@
+#!/usr/bin/env python3
+"""
+Comprehensive test suite for POST /v1/responses endpoint.
+
+Validates the full Responses API contract including:
+  1. Non-streaming with string input
+  2. Non-streaming with message array input
+  3. Non-streaming with instructions (system prompt)
+  4. Non-streaming with developer role (maps to system)
+  5. Non-streaming with input_text content parts
+  6. Streaming SSE event sequence
+  7. Streaming SSE event structure validation
+  8. Tool/function call definitions (flat format)
+  9. Error cases (empty input, missing auth)
+  10. Response schema field-level validation
+
+Prerequisites:
+  - CatGPT API server running: python -m src.api.server
+  - API_TOKEN must match .env (default: dummy123)
+
+Usage:
+  python scripts/test_responses_api.py
+  python scripts/test_responses_api.py --base-url http://host:port
+  python scripts/test_responses_api.py --test 1    # run a specific test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+import httpx
+
+# Load .env if dotenv is available
+try:
+    from dotenv import load_dotenv
+    load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+except ImportError:
+    pass
+
+
+# ── Configuration ───────────────────────────────────────────────
+
+DEFAULT_BASE = "http://localhost:8000"
+API_KEY = os.environ.get("API_TOKEN", "dummy123")
+
+PASSED = 0
+FAILED = 0
+SKIPPED = 0
+ERRORS: list[str] = []
+
+
+# ── Helpers ─────────────────────────────────────────────────────
+
+def separator(title: str) -> None:
+    print(f"\n{'=' * 64}")
+    print(f"  {title}")
+    print(f"{'=' * 64}")
+
+
+def ok(msg: str) -> None:
+    global PASSED
+    PASSED += 1
+    print(f"  ✅ {msg}")
+
+
+def fail(msg: str) -> None:
+    global FAILED
+    FAILED += 1
+    ERRORS.append(msg)
+    print(f"  ❌ {msg}")
+
+
+def skip(msg: str) -> None:
+    global SKIPPED
+    SKIPPED += 1
+    print(f"  ⏭️  {msg}")
+
+
+def assert_eq(label: str, actual, expected):
+    if actual == expected:
+        ok(f"{label}: {actual!r}")
+    else:
+        fail(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def assert_in(label: str, value, container):
+    if value in container:
+        ok(f"{label}: {value!r} found")
+    else:
+        fail(f"{label}: {value!r} not in {container!r}")
+
+
+def assert_type(label: str, value, expected_type):
+    if isinstance(value, expected_type):
+        ok(f"{label}: type is {type(value).__name__}")
+    else:
+        fail(f"{label}: expected {expected_type.__name__}, got {type(value).__name__}")
+
+
+def assert_truthy(label: str, value):
+    if value:
+        ok(f"{label}")
+    else:
+        fail(f"{label}: value is falsy: {value!r}")
+
+
+def assert_nonempty_string(label: str, value):
+    if isinstance(value, str) and len(value) > 0:
+        ok(f"{label}: \"{value[:60]}{'...' if len(value) > 60 else ''}\"")
+    else:
+        fail(f"{label}: expected non-empty string, got {value!r}")
+
+
+def post_responses(client: httpx.Client, body: dict, stream: bool = False):
+    """POST to /v1/responses. Returns parsed JSON or raw response for streaming."""
+    if stream:
+        return client.post("/v1/responses", json=body, timeout=180.0)
+    r = client.post("/v1/responses", json=body, timeout=180.0)
+    r.raise_for_status()
+    return r.json()
+
+
+def parse_sse_events(text: str) -> list[dict]:
+    """Parse SSE event stream text into list of {event, data} dicts."""
+    events = []
+    current_event = None
+    current_data_lines = []
+
+    for line in text.split("\n"):
+        if line.startswith("event: "):
+            current_event = line[7:].strip()
+        elif line.startswith("data: "):
+            current_data_lines.append(line[6:])
+        elif line == "" and current_event is not None:
+            data_str = "\n".join(current_data_lines)
+            try:
+                data = json.loads(data_str)
+            except json.JSONDecodeError:
+                data = data_str
+            events.append({"event": current_event, "data": data})
+            current_event = None
+            current_data_lines = []
+
+    # Handle trailing event without final blank line
+    if current_event is not None and current_data_lines:
+        data_str = "\n".join(current_data_lines)
+        try:
+            data = json.loads(data_str)
+        except json.JSONDecodeError:
+            data = data_str
+        events.append({"event": current_event, "data": data})
+
+    return events
+
+
+# ── Response Schema Validator ───────────────────────────────────
+
+def validate_response_object(resp: dict, label: str = "response"):
+    """Validate that a response object has all required fields with correct types."""
+    # Required string fields
+    assert_truthy(f"{label}.id starts with resp_", resp.get("id", "").startswith("resp_"))
+    assert_eq(f"{label}.object", resp.get("object"), "response")
+    assert_in(f"{label}.status", resp.get("status"), ["completed", "in_progress", "failed", "incomplete"])
+    assert_type(f"{label}.created_at", resp.get("created_at"), int)
+    assert_type(f"{label}.model", resp.get("model"), str)
+
+    # Output array
+    assert_type(f"{label}.output", resp.get("output"), list)
+
+    # Metadata
+    assert_type(f"{label}.metadata", resp.get("metadata"), dict)
+
+    # Tools echo
+    assert_type(f"{label}.tools", resp.get("tools"), list)
+
+    # Text format
+    text_field = resp.get("text")
+    if text_field is not None:
+        assert_type(f"{label}.text", text_field, dict)
+        assert_eq(f"{label}.text.format.type", text_field.get("format", {}).get("type"), "text")
+
+
+def validate_output_message(item: dict, label: str = "output[0]"):
+    """Validate a message output item."""
+    assert_eq(f"{label}.type", item.get("type"), "message")
+    assert_eq(f"{label}.role", item.get("role"), "assistant")
+    assert_eq(f"{label}.status", item.get("status"), "completed")
+    assert_type(f"{label}.content", item.get("content"), list)
+
+    if item.get("content"):
+        part = item["content"][0]
+        assert_eq(f"{label}.content[0].type", part.get("type"), "output_text")
+        assert_type(f"{label}.content[0].text", part.get("text"), str)
+        assert_truthy(f"{label}.content[0].text is non-empty", len(part.get("text", "")) > 0)
+        assert_type(f"{label}.content[0].annotations", part.get("annotations"), list)
+
+
+def validate_usage(usage: dict, label: str = "usage"):
+    """Validate usage object."""
+    assert_type(f"{label}.input_tokens", usage.get("input_tokens"), int)
+    assert_type(f"{label}.output_tokens", usage.get("output_tokens"), int)
+    assert_type(f"{label}.total_tokens", usage.get("total_tokens"), int)
+    assert_truthy(
+        f"{label}.total_tokens = input + output",
+        usage.get("total_tokens") == usage.get("input_tokens", 0) + usage.get("output_tokens", 0),
+    )
+    details = usage.get("output_tokens_details")
+    assert_type(f"{label}.output_tokens_details", details, dict)
+
+
+# ── Tests ───────────────────────────────────────────────────────
+
+def test_1_string_input(client: httpx.Client):
+    """Non-streaming: simple string input."""
+    separator("Test 1: Non-streaming — string input")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "input": "What is the capital of Japan? Reply with the city name only.",
+        "stream": False,
+    })
+
+    validate_response_object(resp)
+    assert_eq("status", resp["status"], "completed")
+    assert_type("completed_at", resp.get("completed_at"), int)
+    assert_nonempty_string("output_text", resp.get("output_text", ""))
+
+    # Validate output array
+    assert_truthy("output has items", len(resp["output"]) > 0)
+    validate_output_message(resp["output"][0])
+
+    # output_text should match the text inside output[0].content[0].text
+    inner_text = resp["output"][0]["content"][0]["text"]
+    assert_eq("output_text matches output[0]", resp["output_text"], inner_text)
+
+    # Usage
+    assert_truthy("usage present", resp.get("usage") is not None)
+    validate_usage(resp["usage"])
+
+    print(f"\n  Model replied: \"{resp['output_text']}\"")
+
+
+def test_2_message_array_input(client: httpx.Client):
+    """Non-streaming: message array input (role + content)."""
+    separator("Test 2: Non-streaming — message array input")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "input": [
+            {"role": "user", "content": "What is 7 * 8? Reply with just the number."},
+        ],
+        "stream": False,
+    })
+
+    validate_response_object(resp)
+    assert_eq("status", resp["status"], "completed")
+    assert_truthy("output has items", len(resp["output"]) > 0)
+    validate_output_message(resp["output"][0])
+    assert_nonempty_string("output_text", resp.get("output_text", ""))
+
+    print(f"\n  Model replied: \"{resp['output_text']}\"")
+
+
+def test_3_instructions(client: httpx.Client):
+    """Non-streaming: instructions field (system prompt)."""
+    separator("Test 3: Non-streaming — instructions (system prompt)")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "instructions": "You must respond in exactly 3 words. No more, no less.",
+        "input": "Describe the ocean.",
+        "stream": False,
+    })
+
+    validate_response_object(resp)
+    assert_eq("instructions echoed", resp.get("instructions"),
+              "You must respond in exactly 3 words. No more, no less.")
+    assert_nonempty_string("output_text", resp.get("output_text", ""))
+
+    print(f"\n  Model replied: \"{resp['output_text']}\"")
+
+
+def test_4_developer_role(client: httpx.Client):
+    """Non-streaming: developer role in input (should map to system)."""
+    separator("Test 4: Non-streaming — developer role input")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "input": [
+            {"role": "developer", "content": "Always respond in ALL CAPS."},
+            {"role": "user", "content": "Say hi."},
+        ],
+        "stream": False,
+    })
+
+    validate_response_object(resp)
+    assert_nonempty_string("output_text", resp.get("output_text", ""))
+
+    print(f"\n  Model replied: \"{resp['output_text']}\"")
+
+
+def test_5_input_text_content_parts(client: httpx.Client):
+    """Non-streaming: input with content parts using input_text type."""
+    separator("Test 5: Non-streaming — input_text content parts")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "What color is the sky? One word answer."},
+                ],
+            },
+        ],
+        "stream": False,
+    })
+
+    validate_response_object(resp)
+    assert_nonempty_string("output_text", resp.get("output_text", ""))
+
+    print(f"\n  Model replied: \"{resp['output_text']}\"")
+
+
+def test_6_streaming_event_sequence(client: httpx.Client):
+    """Streaming: validate complete SSE event sequence."""
+    separator("Test 6: Streaming — SSE event sequence")
+
+    with client.stream(
+        "POST",
+        "/v1/responses",
+        json={
+            "model": "catgpt-browser",
+            "input": "What is 1+1? Reply with the number only.",
+            "stream": True,
+        },
+        timeout=300.0,
+    ) as r:
+        r.raise_for_status()
+        body = r.read().decode()
+
+    events = parse_sse_events(body)
+    event_types = [e["event"] for e in events]
+
+    print(f"  Received {len(events)} SSE events")
+    for i, e in enumerate(events):
+        seq = e["data"].get("sequence_number", "?") if isinstance(e["data"], dict) else "?"
+        print(f"    [{i}] seq={seq} {e['event']}")
+
+    # Validate required event order
+    REQUIRED_SEQUENCE = [
+        "response.created",
+        "response.in_progress",
+        "response.output_item.added",
+        "response.content_part.added",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.content_part.done",
+        "response.output_item.done",
+        "response.completed",
+    ]
+
+    assert_truthy(f"at least {len(REQUIRED_SEQUENCE)} events", len(events) >= len(REQUIRED_SEQUENCE))
+
+    # Check sequence order (events should appear in this order)
+    last_idx = -1
+    for expected_type in REQUIRED_SEQUENCE:
+        try:
+            idx = event_types.index(expected_type)
+        except ValueError:
+            fail(f"Missing required event: {expected_type}")
+            continue
+        if idx > last_idx:
+            ok(f"Event order: {expected_type} at position {idx}")
+            last_idx = idx
+        else:
+            fail(f"Event order: {expected_type} at position {idx} but expected after {last_idx}")
+
+    # Validate sequence_number is monotonically increasing
+    seq_numbers = []
+    for e in events:
+        if isinstance(e["data"], dict):
+            seq_numbers.append(e["data"].get("sequence_number", -1))
+    is_monotonic = all(seq_numbers[i] < seq_numbers[i + 1] for i in range(len(seq_numbers) - 1))
+    if is_monotonic:
+        ok(f"Sequence numbers monotonically increasing: {seq_numbers}")
+    else:
+        fail(f"Sequence numbers NOT monotonic: {seq_numbers}")
+
+
+def test_7_streaming_event_content(client: httpx.Client):
+    """Streaming: validate individual event payloads."""
+    separator("Test 7: Streaming — event payload validation")
+
+    with client.stream(
+        "POST",
+        "/v1/responses",
+        json={
+            "model": "catgpt-browser",
+            "input": "Say the word 'test'. Nothing else.",
+            "stream": True,
+        },
+        timeout=300.0,
+    ) as r:
+        r.raise_for_status()
+        body = r.read().decode()
+
+    events = parse_sse_events(body)
+    events_by_type = {e["event"]: e["data"] for e in events}
+
+    # response.created
+    created = events_by_type.get("response.created", {})
+    created_resp = created.get("response", {})
+    assert_eq("created.status", created_resp.get("status"), "in_progress")
+    assert_eq("created.output", created_resp.get("output"), [])
+    assert_eq("created.output_text", created_resp.get("output_text"), None)
+    assert_eq("created.usage", created_resp.get("usage"), None)
+    assert_truthy("created.id starts with resp_", created_resp.get("id", "").startswith("resp_"))
+
+    # response.output_item.added
+    item_added = events_by_type.get("response.output_item.added", {})
+    assert_eq("item_added.output_index", item_added.get("output_index"), 0)
+    item = item_added.get("item", {})
+    assert_eq("item_added.item.type", item.get("type"), "message")
+    assert_eq("item_added.item.role", item.get("role"), "assistant")
+    assert_eq("item_added.item.status", item.get("status"), "in_progress")
+    assert_eq("item_added.item.content", item.get("content"), [])
+
+    # response.content_part.added
+    part_added = events_by_type.get("response.content_part.added", {})
+    assert_eq("part_added.content_index", part_added.get("content_index"), 0)
+    part = part_added.get("part", {})
+    assert_eq("part_added.part.type", part.get("type"), "output_text")
+    assert_eq("part_added.part.text", part.get("text"), "")
+
+    # response.output_text.delta
+    delta_evt = events_by_type.get("response.output_text.delta", {})
+    assert_eq("delta.output_index", delta_evt.get("output_index"), 0)
+    assert_eq("delta.content_index", delta_evt.get("content_index"), 0)
+    assert_nonempty_string("delta.delta", delta_evt.get("delta", ""))
+
+    # response.output_text.done
+    text_done = events_by_type.get("response.output_text.done", {})
+    assert_nonempty_string("text_done.text", text_done.get("text", ""))
+    assert_eq("delta matches done text", delta_evt.get("delta"), text_done.get("text"))
+
+    # response.content_part.done
+    part_done = events_by_type.get("response.content_part.done", {})
+    assert_eq("part_done.part.text matches", part_done.get("part", {}).get("text"), text_done.get("text"))
+
+    # response.output_item.done
+    item_done = events_by_type.get("response.output_item.done", {})
+    done_item = item_done.get("item", {})
+    assert_eq("item_done.item.status", done_item.get("status"), "completed")
+    assert_truthy("item_done.item.content non-empty", len(done_item.get("content", [])) > 0)
+
+    # response.completed
+    completed = events_by_type.get("response.completed", {})
+    completed_resp = completed.get("response", {})
+    assert_eq("completed.status", completed_resp.get("status"), "completed")
+    assert_type("completed.completed_at", completed_resp.get("completed_at"), int)
+    assert_truthy("completed.usage present", completed_resp.get("usage") is not None)
+    assert_truthy("completed.output non-empty", len(completed_resp.get("output", [])) > 0)
+    assert_nonempty_string("completed.output_text", completed_resp.get("output_text", ""))
+
+    # IDs should be consistent
+    item_id_added = item_added.get("item", {}).get("id")
+    item_id_delta = delta_evt.get("item_id")
+    item_id_done = item_done.get("item", {}).get("id")
+    assert_eq("item_id consistent (added vs delta)", item_id_added, item_id_delta)
+    assert_eq("item_id consistent (added vs done)", item_id_added, item_id_done)
+
+    # Created response ID matches completed response ID
+    assert_eq(
+        "response.id consistent (created vs completed)",
+        created_resp.get("id"),
+        completed_resp.get("id"),
+    )
+
+
+def test_8_tools_definition(client: httpx.Client):
+    """Non-streaming: tools are accepted and echoed in flat format."""
+    separator("Test 8: Non-streaming — tools definition echo")
+
+    tools = [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get the current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "City name"},
+                },
+                "required": ["city"],
+            },
+        },
+    ]
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "input": "What's the weather in Paris?",
+        "tools": tools,
+        "stream": False,
+    })
+
+    validate_response_object(resp)
+
+    # Tools should be echoed back
+    assert_truthy("tools echoed in response", len(resp.get("tools", [])) > 0)
+    echoed_tool = resp["tools"][0]
+    assert_eq("echoed tool.name", echoed_tool.get("name"), "get_weather")
+    assert_eq("echoed tool.type", echoed_tool.get("type"), "function")
+
+    # Response should be either a text answer or a function_call
+    output = resp.get("output", [])
+    assert_truthy("output has items", len(output) > 0)
+
+    first_output = output[0]
+    output_type = first_output.get("type")
+    assert_in("output type", output_type, ["message", "function_call"])
+
+    if output_type == "function_call":
+        assert_eq("function_call.name", first_output.get("name"), "get_weather")
+        assert_nonempty_string("function_call.arguments", first_output.get("arguments", ""))
+        assert_truthy("function_call.call_id present", first_output.get("call_id"))
+        assert_eq("function_call.status", first_output.get("status"), "completed")
+        print(f"\n  Model called tool: {first_output['name']}({first_output['arguments']})")
+    else:
+        print(f"\n  Model answered directly: \"{resp.get('output_text', '')[:80]}\"")
+
+
+def test_9_error_empty_input(client: httpx.Client):
+    """Error case: empty input should return 400."""
+    separator("Test 9: Error — empty input")
+
+    r = client.post("/v1/responses", json={
+        "model": "catgpt-browser",
+        "input": "",
+        "stream": False,
+    })
+
+    assert_eq("status_code", r.status_code, 400)
+    body = r.json()
+    assert_truthy("error detail present", "detail" in body)
+    print(f"  Error message: {body.get('detail')}")
+
+
+def test_10_error_no_auth(base_url: str):
+    """Error case: missing auth token should return 401."""
+    separator("Test 10: Error — missing auth token")
+
+    # Create client WITHOUT auth header
+    no_auth_client = httpx.Client(base_url=base_url, timeout=httpx.Timeout(30.0, connect=10.0))
+    try:
+        r = no_auth_client.post("/v1/responses", json={
+            "model": "catgpt-browser",
+            "input": "hello",
+            "stream": False,
+        })
+        assert_eq("status_code", r.status_code, 401)
+    finally:
+        no_auth_client.close()
+
+
+def test_11_metadata_passthrough(client: httpx.Client):
+    """Non-streaming: metadata and previous_response_id are accepted and echoed."""
+    separator("Test 11: Non-streaming — metadata & previous_response_id")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "input": "Say OK.",
+        "metadata": {"user_id": "test-123", "session": "abc"},
+        "previous_response_id": "resp_fake_previous_id",
+        "stream": False,
+    })
+
+    validate_response_object(resp)
+    assert_eq("metadata.user_id", resp.get("metadata", {}).get("user_id"), "test-123")
+    assert_eq("metadata.session", resp.get("metadata", {}).get("session"), "abc")
+    assert_eq("previous_response_id", resp.get("previous_response_id"), "resp_fake_previous_id")
+
+    print(f"\n  Model replied: \"{resp.get('output_text', '')}\"")
+
+
+def test_12_multi_message_conversation(client: httpx.Client):
+    """Non-streaming: multi-turn conversation in input array."""
+    separator("Test 12: Non-streaming — multi-turn conversation")
+
+    resp = post_responses(client, {
+        "model": "catgpt-browser",
+        "input": [
+            {"role": "user", "content": "Remember this number: 42"},
+            {"role": "assistant", "content": "Got it, I'll remember the number 42."},
+            {"role": "user", "content": "What number did I ask you to remember? Reply with just the number."},
+        ],
+        "stream": False,
+    })
+
+    validate_response_object(resp)
+    assert_nonempty_string("output_text", resp.get("output_text", ""))
+
+    print(f"\n  Model replied: \"{resp['output_text']}\"")
+
+
+# ── Main ────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Test /v1/responses endpoint")
+    parser.add_argument("--base-url", default=DEFAULT_BASE, help="API base URL")
+    parser.add_argument("--test", type=int, help="Run a specific test number (1-12)")
+    parser.add_argument("--api-key", default=API_KEY, help="API bearer token")
+    args = parser.parse_args()
+
+    base_url = args.base_url.rstrip("/")
+
+    client = httpx.Client(
+        base_url=base_url,
+        headers={"Authorization": f"Bearer {args.api_key}"},
+        timeout=httpx.Timeout(180.0, connect=10.0),
+    )
+
+    ALL_TESTS = [
+        # Error tests first — they don't hit the browser
+        (9, test_9_error_empty_input),
+        (10, test_10_error_no_auth),
+        # Non-streaming tests
+        (1, test_1_string_input),
+        (2, test_2_message_array_input),
+        (3, test_3_instructions),
+        (4, test_4_developer_role),
+        (5, test_5_input_text_content_parts),
+        # Streaming tests (need breathing room after non-streaming)
+        (6, test_6_streaming_event_sequence),
+        (7, test_7_streaming_event_content),
+        # Tool calling + metadata + multi-turn
+        (8, test_8_tools_definition),
+        (11, test_11_metadata_passthrough),
+        (12, test_12_multi_message_conversation),
+    ]
+
+    # Tests that hit the browser — need a delay between them
+    BROWSER_TESTS = {1, 2, 3, 4, 5, 6, 7, 8, 11, 12}
+
+    print("\n" + "=" * 64)
+    print("  CatGPT Gateway — /v1/responses API Test Suite")
+    print("=" * 64)
+    print(f"  Base URL : {base_url}")
+    print(f"  Auth     : Bearer {args.api_key[:4]}{'*' * (len(args.api_key) - 4)}")
+
+    # Check server is reachable
+    try:
+        r = client.get("/health")
+        if r.status_code != 200:
+            print(f"\n  ⚠️  /health returned {r.status_code} — server may not be ready")
+        else:
+            print(f"  Health   : OK")
+    except httpx.ConnectError:
+        print(f"\n  ❌ Cannot connect to {base_url}")
+        print("     Start the server first: python -m src.api.server")
+        sys.exit(1)
+
+    start_time = time.time()
+    last_was_browser = False
+
+    for num, test_fn in ALL_TESTS:
+        if args.test is not None and num != args.test:
+            continue
+
+        # Delay between browser-hitting tests to prevent ChatGPT rate limits
+        is_browser = num in BROWSER_TESTS
+        if is_browser and last_was_browser:
+            print("\n  ⏳ Waiting 5s between browser tests...")
+            time.sleep(5)
+
+        try:
+            if test_fn == test_10_error_no_auth:
+                test_fn(base_url)
+            else:
+                test_fn(client)
+        except httpx.HTTPStatusError as e:
+            try:
+                body = e.response.text
+            except httpx.ResponseNotRead:
+                body = "(streaming response not read)"
+            fail(f"Test {num} HTTP error: {e.response.status_code} — {body[:200]}")
+        except (httpx.ReadTimeout, httpx.ConnectTimeout) as e:
+            fail(f"Test {num} timeout: {e}")
+        except Exception as e:
+            fail(f"Test {num} exception: {e}")
+            traceback.print_exc()
+
+        last_was_browser = is_browser
+
+    client.close()
+    elapsed = time.time() - start_time
+
+    # Summary
+    print(f"\n{'=' * 64}")
+    print(f"  RESULTS: {PASSED} passed, {FAILED} failed, {SKIPPED} skipped")
+    print(f"  Time: {elapsed:.1f}s")
+    print(f"{'=' * 64}")
+
+    if ERRORS:
+        print("\n  Failures:")
+        for err in ERRORS:
+            print(f"    • {err}")
+
+    print()
+    sys.exit(1 if FAILED > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/openai_routes.py
+++ b/src/api/openai_routes.py
@@ -1393,12 +1393,6 @@ def _build_cardinality_retry_prompt(
 
 def _validate_chat_request(request: ChatCompletionRequest) -> None:
     """Shared validation for chat completion request payloads."""
-    if request.stream:
-        raise HTTPException(
-            status_code=400,
-            detail="Streaming is not supported. Set stream=false or omit it.",
-        )
-
     if not request.messages:
         raise HTTPException(status_code=400, detail="messages array cannot be empty")
 
@@ -1647,6 +1641,8 @@ async def create_chat_completion(
     """
     _validate_chat_request(request)
     app_key = _resolve_app_key(request, http_request)
+    if request.stream:
+        return await _stream_chat_completion(request, app_key_override=app_key)
     return await _execute_chat_completion(request, app_key_override=app_key)
 
 
@@ -1691,6 +1687,8 @@ async def create_chat_completion_scoped(
     """App-scoped alias for chat completions (maps app name from URL path)."""
     _validate_chat_request(request)
     app_key = _resolve_app_key(request, http_request, endpoint_app_name=app_name)
+    if request.stream:
+        return await _stream_chat_completion(request, app_key_override=app_key)
     return await _execute_chat_completion(request, app_key_override=app_key)
 
 
@@ -1812,6 +1810,92 @@ def _responses_response_from_chat(
 def _responses_sse_event(event: str, data: dict[str, Any]) -> str:
     payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
     return f"event: {event}\ndata: {payload}\n\n"
+
+
+def _chat_completion_sse_chunk(
+    response: ChatCompletionResponse,
+    delta: dict[str, Any],
+    *,
+    finish_reason: str | None = None,
+) -> str:
+    """Format one OpenAI chat.completion.chunk SSE data line."""
+    chunk = {
+        "id": response.id,
+        "object": "chat.completion.chunk",
+        "created": response.created,
+        "model": response.model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": delta,
+                "finish_reason": finish_reason,
+            }
+        ],
+    }
+    payload = json.dumps(chunk, ensure_ascii=False, separators=(",", ":"))
+    return f"data: {payload}\n\n"
+
+
+async def _stream_chat_completion(
+    request: ChatCompletionRequest,
+    app_key_override: str = "",
+) -> StreamingResponse:
+    """Return a Chat Completions SSE stream after the browser response completes.
+
+    Browser automation cannot provide token deltas, but IDE clients (OpenCode,
+    Cline, etc.) send stream=true and require text/event-stream. Emit the full
+    assistant message as one or two chunks plus a terminal finish chunk.
+    """
+
+    async def _events():
+        non_stream_request = request.model_copy(update={"stream": False})
+        response = await _execute_chat_completion(
+            non_stream_request,
+            app_key_override=app_key_override,
+        )
+        choice = response.choices[0]
+        message = choice.message
+
+        yield _chat_completion_sse_chunk(
+            response,
+            {"role": "assistant", "content": ""},
+        )
+
+        if message.content:
+            yield _chat_completion_sse_chunk(response, {"content": message.content})
+
+        if message.tool_calls:
+            tool_deltas: list[dict[str, Any]] = []
+            for index, call in enumerate(message.tool_calls):
+                tool_deltas.append(
+                    {
+                        "index": index,
+                        "id": call.id,
+                        "type": call.type,
+                        "function": {
+                            "name": call.function.name,
+                            "arguments": call.function.arguments,
+                        },
+                    }
+                )
+            yield _chat_completion_sse_chunk(response, {"tool_calls": tool_deltas})
+
+        yield _chat_completion_sse_chunk(
+            response,
+            {},
+            finish_reason=choice.finish_reason,
+        )
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(
+        _events(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 async def _stream_responses(

--- a/src/api/openai_routes.py
+++ b/src/api/openai_routes.py
@@ -19,6 +19,7 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
 
 from src.api.openai_schemas import (
     ChatCompletionRequest,
@@ -27,11 +28,18 @@ from src.api.openai_schemas import (
     Choice,
     ChoiceMessage,
     FunctionCallInfo,
+    FunctionDefinition,
     ImageData,
     ImageGenerationRequest,
     ImagesResponse,
     ModelListResponse,
     ModelObject,
+    ResponseFunctionCall,
+    ResponseObject,
+    ResponseOutputMessage,
+    ResponseOutputText,
+    ResponsesRequest,
+    ResponseUsage,
     ToolCall,
     ToolDefinition,
     UsageInfo,
@@ -48,8 +56,71 @@ openai_router = APIRouter()
 # Global reference — set by server.py at startup
 _client: ChatGPTClient | ClaudeClient | None = None
 
-# Serialize all requests — single browser page, not thread-safe
-_lock = asyncio.Lock()
+# Serialize all requests — single browser page, not thread-safe.
+# Created lazily to avoid Python 3.9 event-loop binding issues.
+_lock: asyncio.Lock | None = None
+
+
+def _get_lock() -> asyncio.Lock:
+    """Get or create the global request lock (lazy init)."""
+    global _lock
+    if _lock is None:
+        _lock = asyncio.Lock()
+    return _lock
+
+
+# Track messages in the current thread to prevent thread exhaustion
+_thread_message_count = 0
+_MAX_THREAD_MESSAGES = 8  # Start a new chat after this many requests
+_last_response_time: float = 0.0
+_MIN_MESSAGE_GAP = 3.0  # Minimum seconds between messages (ChatGPT needs cooldown)
+
+
+async def _ensure_fresh_chat() -> None:
+    """Enforce cooldown between messages and start new chat if thread is full.
+
+    ChatGPT's web UI degrades after ~6-8 messages in a thread (stops
+    generating, copy-button never appears). We preemptively start a
+    new chat after _MAX_THREAD_MESSAGES to prevent this.
+
+    Also enforces a minimum gap between consecutive messages, since
+    ChatGPT's UI may not accept rapid-fire messages properly.
+    """
+    global _thread_message_count, _last_response_time
+
+    # Enforce minimum gap between messages
+    if _last_response_time > 0:
+        elapsed = time.time() - _last_response_time
+        if elapsed < _MIN_MESSAGE_GAP:
+            wait = _MIN_MESSAGE_GAP - elapsed
+            log.debug(f"Cooldown: waiting {wait:.1f}s before next message")
+            await asyncio.sleep(wait)
+
+    if _thread_message_count < _MAX_THREAD_MESSAGES:
+        return  # Thread is fresh enough — no navigation needed
+
+    client = _get_client()
+    try:
+        await client.new_chat()
+        _thread_message_count = 0
+    except Exception as e:
+        log.warning(f"new_chat() failed, retrying once: {e}")
+        try:
+            await asyncio.sleep(2)
+            await client.new_chat()
+            _thread_message_count = 0
+        except Exception as e2:
+            log.error(f"new_chat() retry also failed: {e2}")
+            # Don't raise — continue with current thread rather than failing
+            log.warning("Continuing with current thread despite new_chat failure")
+
+
+def _increment_thread_count() -> None:
+    """Increment the thread message counter after a successful response."""
+    global _thread_message_count, _last_response_time
+    _thread_message_count += 1
+    _last_response_time = time.time()
+    log.debug(f"Thread message count: {_thread_message_count}/{_MAX_THREAD_MESSAGES}")
 
 
 def _get_model_id() -> str:
@@ -571,7 +642,7 @@ async def create_image(
 
     client = _get_client()
 
-    async with _lock:
+    async with _get_lock():
         start_time = time.time()
 
         # Build an image-generation prompt.
@@ -593,6 +664,9 @@ async def create_image(
             f"POST /v1/images/generations — prompt='{request.prompt[:80]}', "
             f"n={request.n}, size={request.size}, response_format={request.response_format}"
         )
+
+        # Start a fresh conversation to avoid thread exhaustion
+        await _ensure_fresh_chat()
 
         # Send to ChatGPT
         try:
@@ -661,6 +735,7 @@ async def create_image(
             f"{elapsed_ms}ms, format={request.response_format}"
         )
 
+        _increment_thread_count()
         return ImagesResponse(data=image_data_list)
 
 
@@ -687,7 +762,7 @@ async def create_chat_completion(
 
     client = _get_client()
 
-    async with _lock:
+    async with _get_lock():
         start_time = time.time()
 
         # ── Build the prompt ────────────────────────────────
@@ -732,6 +807,9 @@ async def create_chat_completion(
         if all_attachment_paths:
             log.info(f"Extracted {len(image_paths)} image(s) and {len(file_paths)} file(s) from request")
 
+        # Start a fresh conversation to avoid thread exhaustion
+        await _ensure_fresh_chat()
+
         # ── Send to ChatGPT ────────────────────────────────
         try:
             result = await client.send_message(
@@ -751,7 +829,7 @@ async def create_chat_completion(
         if response_text and has_tool_prompt and any(m in response_text for m in _echo_markers):
             log.warning("Response appears to echo the sent prompt — retrying extraction")
             try:
-                await asyncio.sleep(3)
+                await asyncio.sleep(1.5)
                 if Config.PROVIDER == "claude":
                     from src.claude.detector import extract_last_response_via_copy
                 else:
@@ -811,4 +889,520 @@ async def create_chat_completion(
             f"tokens≈{response.usage.total_tokens}"
         )
 
+        _increment_thread_count()
         return response
+
+
+# ── Responses API (/v1/responses) ───────────────────────────────
+
+
+def _responses_input_to_messages(
+    input_data: str | list,
+    instructions: str | None = None,
+) -> list[ChatMessage]:
+    """
+    Convert Responses API `input` (string or item array) into a list of
+    ChatMessage objects compatible with our existing _build_prompt().
+
+    Handles:
+      - Plain string → single user message
+      - Array of message objects (role + content)
+      - function_call items (assistant requested a tool)
+      - function_call_output items (tool results)
+    """
+    messages: list[ChatMessage] = []
+
+    # System prompt from `instructions`
+    if instructions:
+        messages.append(ChatMessage(role="system", content=instructions))
+
+    # Simple string input
+    if isinstance(input_data, str):
+        messages.append(ChatMessage(role="user", content=input_data))
+        return messages
+
+    # Array of items
+    for item in input_data:
+        if isinstance(item, str):
+            messages.append(ChatMessage(role="user", content=item))
+            continue
+        if not isinstance(item, dict):
+            continue
+
+        item_type = item.get("type")
+        role = item.get("role")
+
+        if item_type == "function_call":
+            # Assistant called a tool — record as assistant message with tool_calls
+            name = item.get("name", "")
+            arguments = item.get("arguments", "{}")
+            call_id = item.get("call_id", f"call_{uuid.uuid4().hex[:24]}")
+            messages.append(
+                ChatMessage(
+                    role="assistant",
+                    tool_calls=[
+                        ToolCall(
+                            id=call_id,
+                            type="function",
+                            function=FunctionCallInfo(
+                                name=name, arguments=arguments
+                            ),
+                        )
+                    ],
+                )
+            )
+        elif item_type == "function_call_output":
+            # Tool result — map to role=tool
+            call_id = item.get("call_id", "")
+            output = item.get("output", "")
+            messages.append(
+                ChatMessage(
+                    role="tool",
+                    content=output,
+                    tool_call_id=call_id,
+                )
+            )
+        elif item_type == "message" or role:
+            # Regular message item
+            r = role or item.get("role", "user")
+            # Map "developer" role to "system"
+            if r == "developer":
+                r = "system"
+            content = item.get("content", "")
+            # Content can be a list of content parts or a string
+            if isinstance(content, list):
+                # Extract text from content parts
+                text_parts = []
+                for part in content:
+                    if isinstance(part, dict):
+                        if part.get("type") == "input_text":
+                            text_parts.append(part.get("text", ""))
+                        elif part.get("type") == "text":
+                            text_parts.append(part.get("text", ""))
+                    elif isinstance(part, str):
+                        text_parts.append(part)
+                content = "\n".join(text_parts) if text_parts else ""
+            messages.append(ChatMessage(role=r, content=content))
+
+    return messages
+
+
+def _responses_tools_to_chat_tools(
+    tools: list[dict],
+) -> list[ToolDefinition]:
+    """
+    Convert flat Responses API tool definitions to nested Chat Completions
+    ToolDefinition format so we can reuse _build_tool_system_prompt().
+
+    Responses:  {"type": "function", "name": "X", "parameters": {...}}
+    Chat:       {"type": "function", "function": {"name": "X", "parameters": {...}}}
+    """
+    result = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            tool = tool.model_dump() if hasattr(tool, "model_dump") else dict(tool)
+        if tool.get("type") != "function":
+            continue
+        result.append(
+            ToolDefinition(
+                type="function",
+                function=FunctionDefinition(
+                    name=tool.get("name", ""),
+                    description=tool.get("description", ""),
+                    parameters=tool.get("parameters", {}),
+                ),
+            )
+        )
+    return result
+
+
+def _build_response_object(
+    response_text: str | None,
+    tool_calls: list[ToolCall] | None,
+    request: "ResponsesRequest",
+    prompt_tokens: int,
+    completion_tokens: int,
+) -> ResponseObject:
+    """Build a full ResponseObject from the model output."""
+    now = int(time.time())
+    output: list = []
+    output_text_val: str | None = None
+
+    if tool_calls:
+        for tc in tool_calls:
+            output.append(
+                ResponseFunctionCall(
+                    name=tc.function.name,
+                    arguments=tc.function.arguments,
+                    call_id=tc.id,
+                ).model_dump()
+            )
+    else:
+        text = response_text or ""
+        msg = ResponseOutputMessage(
+            content=[ResponseOutputText(text=text)]
+        )
+        output.append(msg.model_dump())
+        output_text_val = text
+
+    usage = ResponseUsage(
+        input_tokens=prompt_tokens,
+        output_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+
+    # Reconstruct tools for the response envelope
+    tools_echo = []
+    if request.tools:
+        for t in request.tools:
+            tools_echo.append(
+                t.model_dump() if hasattr(t, "model_dump") else dict(t)
+            )
+
+    return ResponseObject(
+        created_at=now,
+        completed_at=now,
+        status="completed",
+        model=request.model,
+        instructions=request.instructions,
+        max_output_tokens=request.max_output_tokens,
+        output=output,
+        output_text=output_text_val,
+        temperature=request.temperature,
+        top_p=request.top_p,
+        tool_choice=request.tool_choice or "auto",
+        tools=tools_echo,
+        previous_response_id=request.previous_response_id,
+        usage=usage,
+        metadata=request.metadata or {},
+    )
+
+
+async def _stream_response_events(
+    resp: ResponseObject,
+    response_text: str | None,
+    tool_calls: list[ToolCall] | None,
+):
+    """
+    Yield SSE events for a streaming Responses API call.
+
+    Since the browser backend doesn't truly stream, we emit the full
+    response as a burst of events matching the OpenAI SSE contract:
+      response.created → response.in_progress →
+      output_item.added → content_part.added →
+      output_text.delta (full text as one chunk) →
+      output_text.done → content_part.done →
+      output_item.done → response.completed
+    """
+    seq = 0
+    resp_dict = resp.model_dump()
+
+    def _event(event_type: str, data: dict) -> str:
+        data["type"] = event_type
+        data["sequence_number"] = seq
+        return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+
+    # 1) response.created
+    created_resp = dict(resp_dict)
+    created_resp["status"] = "in_progress"
+    created_resp["completed_at"] = None
+    created_resp["output"] = []
+    created_resp["output_text"] = None
+    created_resp["usage"] = None
+    yield _event("response.created", {"response": created_resp})
+    seq += 1
+
+    # 2) response.in_progress
+    yield _event("response.in_progress", {"response": created_resp})
+    seq += 1
+
+    if tool_calls:
+        # Emit function call output items
+        for idx, tc in enumerate(tool_calls):
+            fc_item = ResponseFunctionCall(
+                name=tc.function.name,
+                arguments=tc.function.arguments,
+                call_id=tc.id,
+            ).model_dump()
+
+            # output_item.added
+            fc_added = dict(fc_item)
+            fc_added["status"] = "in_progress"
+            yield _event("response.output_item.added", {
+                "output_index": idx,
+                "item": fc_added,
+            })
+            seq += 1
+
+            # function_call_arguments.delta (one burst)
+            yield _event("response.function_call_arguments.delta", {
+                "item_id": fc_item["id"],
+                "output_index": idx,
+                "delta": tc.function.arguments,
+            })
+            seq += 1
+
+            # function_call_arguments.done
+            yield _event("response.function_call_arguments.done", {
+                "item_id": fc_item["id"],
+                "output_index": idx,
+                "name": tc.function.name,
+                "arguments": tc.function.arguments,
+            })
+            seq += 1
+
+            # output_item.done
+            yield _event("response.output_item.done", {
+                "output_index": idx,
+                "item": fc_item,
+            })
+            seq += 1
+    else:
+        # Emit text message output
+        text = response_text or ""
+        msg = ResponseOutputMessage(
+            content=[ResponseOutputText(text=text)]
+        )
+        msg_dict = msg.model_dump()
+
+        # output_item.added (empty content)
+        msg_added = dict(msg_dict)
+        msg_added["status"] = "in_progress"
+        msg_added["content"] = []
+        yield _event("response.output_item.added", {
+            "output_index": 0,
+            "item": msg_added,
+        })
+        seq += 1
+
+        # content_part.added
+        yield _event("response.content_part.added", {
+            "item_id": msg_dict["id"],
+            "output_index": 0,
+            "content_index": 0,
+            "part": {"type": "output_text", "text": "", "annotations": []},
+        })
+        seq += 1
+
+        # output_text.delta — full text as one chunk
+        if text:
+            yield _event("response.output_text.delta", {
+                "item_id": msg_dict["id"],
+                "output_index": 0,
+                "content_index": 0,
+                "delta": text,
+            })
+            seq += 1
+
+        # output_text.done
+        yield _event("response.output_text.done", {
+            "item_id": msg_dict["id"],
+            "output_index": 0,
+            "content_index": 0,
+            "text": text,
+        })
+        seq += 1
+
+        # content_part.done
+        yield _event("response.content_part.done", {
+            "item_id": msg_dict["id"],
+            "output_index": 0,
+            "content_index": 0,
+            "part": {"type": "output_text", "text": text, "annotations": []},
+        })
+        seq += 1
+
+        # output_item.done
+        yield _event("response.output_item.done", {
+            "output_index": 0,
+            "item": msg_dict,
+        })
+        seq += 1
+
+    # response.completed
+    yield _event("response.completed", {"response": resp_dict})
+
+
+@openai_router.post("/v1/responses")
+async def create_response(request: ResponsesRequest):
+    """
+    OpenAI Responses API endpoint — compatible with Codex CLI.
+
+    Accepts the Responses API format (flat tools, `input` field, `instructions`),
+    translates to our internal format, sends to the browser, and returns a
+    Responses-API-shaped response (or SSE stream).
+    """
+    # ── Validate ────────────────────────────────────────────
+    if not request.input:
+        raise HTTPException(status_code=400, detail="input cannot be empty")
+
+    client = _get_client()
+
+    async with _get_lock():
+        start_time = time.time()
+
+        # ── Convert input to ChatMessage list ───────────────
+        messages = _responses_input_to_messages(
+            request.input, instructions=request.instructions
+        )
+
+        # ── Convert flat tools to nested format ─────────────
+        chat_tools: list[ToolDefinition] | None = None
+        has_tool_prompt = False
+        if request.tools:
+            raw_tools = [
+                t.model_dump() if hasattr(t, "model_dump") else dict(t)
+                for t in request.tools
+            ]
+            chat_tools = _responses_tools_to_chat_tools(raw_tools)
+            if chat_tools and request.tool_choice != "none":
+                tool_system = _build_tool_system_prompt(
+                    chat_tools, tool_choice=request.tool_choice
+                )
+                messages.insert(
+                    0, ChatMessage(role="system", content=tool_system)
+                )
+                has_tool_prompt = True
+
+        prompt = _build_prompt(messages)
+        log.info(
+            f"POST /v1/responses — model={request.model}, "
+            f"input_type={'string' if isinstance(request.input, str) else 'array'}, "
+            f"prompt={len(prompt)} chars, stream={request.stream}"
+        )
+
+        # Start a fresh conversation to avoid thread exhaustion
+        await _ensure_fresh_chat()
+
+        # ── Send to browser ────────────────────────────────
+        try:
+            result = await client.send_message(prompt)
+        except RuntimeError as e:
+            err_msg = str(e).lower()
+            if "error state" in err_msg or "could not find chat input" in err_msg:
+                # Page has a DNS/navigation error or UI is broken — attempt recovery
+                log.warning(f"Page error detected, attempting recovery: {e}")
+                from src.api.server import _browser
+                if _browser and await _browser.recover_page():
+                    # Retry after recovery
+                    try:
+                        result = await client.send_message(prompt)
+                    except Exception as e2:
+                        log.error(f"Provider error after recovery: {e2}", exc_info=True)
+                        raise HTTPException(
+                            status_code=500, detail=f"Provider error: {str(e2)}"
+                        )
+                else:
+                    raise HTTPException(
+                        status_code=503, detail="Browser page is in error state and recovery failed"
+                    )
+            else:
+                log.error(f"Provider error: {e}", exc_info=True)
+                raise HTTPException(
+                    status_code=500, detail=f"Provider error: {str(e)}"
+                )
+        except Exception as e:
+            err_name = type(e).__name__
+            # TargetClosedError means browser/page crashed — try recovery
+            if "TargetClosed" in err_name or "closed" in str(e).lower():
+                log.warning(f"Browser/page crashed ({err_name}), attempting recovery...")
+                from src.api.server import _browser
+                if _browser and await _browser.recover_page():
+                    try:
+                        result = await client.send_message(prompt)
+                    except Exception as e2:
+                        log.error(f"Provider error after crash recovery: {e2}", exc_info=True)
+                        raise HTTPException(
+                            status_code=500, detail=f"Provider error: {str(e2)}"
+                        )
+                else:
+                    raise HTTPException(
+                        status_code=503, detail=f"Browser crashed and recovery failed: {err_name}"
+                    )
+            else:
+                log.error(f"Provider error: {e}", exc_info=True)
+                raise HTTPException(
+                    status_code=500, detail=f"Provider error: {str(e)}"
+                )
+
+        response_text = result.message
+        elapsed_ms = int((time.time() - start_time) * 1000)
+
+        # ── Detect echo ────────────────────────────────────
+        _echo_markers = [
+            "[System instruction:",
+            "tool-calling mode",
+            "Available functions:",
+        ]
+        if (
+            response_text
+            and has_tool_prompt
+            and any(m in response_text for m in _echo_markers)
+        ):
+            log.warning(
+                "Response appears to echo the sent prompt — retrying extraction"
+            )
+            try:
+                await asyncio.sleep(1.5)
+                if Config.PROVIDER == "claude":
+                    from src.claude.detector import extract_last_response_via_copy
+                else:
+                    from src.chatgpt.detector import extract_last_response_via_copy
+
+                retry_text = await extract_last_response_via_copy(client.page)
+                if retry_text and not any(
+                    m in retry_text for m in _echo_markers
+                ):
+                    response_text = retry_text
+                    log.info(
+                        f"Retry extraction succeeded: {len(response_text)} chars"
+                    )
+                else:
+                    log.warning(
+                        "Retry extraction still echoed — stripping system prefix"
+                    )
+                    idx = response_text.rfind("\n\n")
+                    if idx > 0:
+                        tail = response_text[idx:].strip()
+                        if tail and not tail.startswith("["):
+                            response_text = tail
+            except Exception as e:
+                log.warning(f"Retry extraction failed: {e}")
+
+        # ── Check for tool calls ────────────────────────────
+        tool_calls = None
+        if has_tool_prompt and chat_tools:
+            tool_calls = _parse_tool_calls(response_text, chat_tools)
+            if tool_calls:
+                response_text = None
+
+        # ── Build response ──────────────────────────────────
+        prompt_tokens = _estimate_tokens(prompt)
+        completion_tokens = _estimate_tokens(response_text or "")
+
+        resp = _build_response_object(
+            response_text, tool_calls, request,
+            prompt_tokens, completion_tokens,
+        )
+
+        log.info(
+            f"Response: {elapsed_ms}ms, "
+            f"tool_calls={len(tool_calls) if tool_calls else 0}, "
+            f"tokens≈{resp.usage.total_tokens if resp.usage else 0}"
+        )
+
+        _increment_thread_count()
+
+        # ── Stream or return ────────────────────────────────
+        if request.stream:
+            return StreamingResponse(
+                _stream_response_events(resp, response_text, tool_calls),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+
+        return resp.model_dump()

--- a/src/api/openai_schemas.py
+++ b/src/api/openai_schemas.py
@@ -162,3 +162,126 @@ class ImagesResponse(BaseModel):
     """OpenAI-compatible image generation response."""
     created: int = Field(default_factory=lambda: int(time.time()))
     data: List[ImageData]
+
+
+# ── Responses API (/v1/responses) ───────────────────────────────
+
+
+class ResponsesToolDefinition(BaseModel):
+    """Flat tool definition used by the Responses API.
+
+    Unlike the Chat Completions API which nests under `function:`,
+    the Responses API uses a flat format:
+      {"type": "function", "name": "...", "parameters": {...}, "description": "..."}
+    """
+    type: str = "function"
+    name: str
+    description: str = ""
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    strict: Optional[bool] = None
+
+
+class ResponsesInputMessage(BaseModel):
+    """A message in the Responses API input array."""
+    role: str  # "user" | "assistant" | "system" | "developer"
+    content: Union[str, List[Any]]
+
+
+class ResponsesFunctionCallInput(BaseModel):
+    """A function_call item in the Responses API input (assistant called a tool)."""
+    type: str = "function_call"
+    id: Optional[str] = None
+    call_id: str
+    name: str
+    arguments: str
+
+
+class ResponsesFunctionCallOutputInput(BaseModel):
+    """A function_call_output item in the Responses API input (tool result)."""
+    type: str = "function_call_output"
+    call_id: str
+    output: str
+
+
+class ResponsesRequest(BaseModel):
+    """Request body for POST /v1/responses."""
+    model: str = "catgpt-browser"
+    input: Union[str, List[Any]]  # string or array of messages/items
+    instructions: Optional[str] = None  # system prompt
+    tools: Optional[List[ResponsesToolDefinition]] = None
+    tool_choice: Optional[Union[str, dict]] = None
+    stream: Optional[bool] = False
+    temperature: Optional[float] = None
+    max_output_tokens: Optional[int] = None
+    top_p: Optional[float] = None
+    previous_response_id: Optional[str] = None
+    truncation: Optional[str] = None
+    user: Optional[str] = None
+    metadata: Optional[dict[str, Any]] = None
+    store: Optional[bool] = None
+
+
+# ── Responses API output models ─────────────────────────────────
+
+
+class ResponseOutputText(BaseModel):
+    """Text content in a Responses API output message."""
+    type: str = "output_text"
+    text: str = ""
+    annotations: List[Any] = Field(default_factory=list)
+
+
+class ResponseOutputMessage(BaseModel):
+    """A message output item in the Responses API."""
+    id: str = Field(default_factory=lambda: f"msg_{uuid.uuid4().hex[:24]}")
+    type: str = "message"
+    role: str = "assistant"
+    status: str = "completed"
+    content: List[ResponseOutputText] = Field(default_factory=list)
+
+
+class ResponseFunctionCall(BaseModel):
+    """A function_call output item in the Responses API."""
+    id: str = Field(default_factory=lambda: f"fc_{uuid.uuid4().hex[:24]}")
+    type: str = "function_call"
+    call_id: str = Field(default_factory=lambda: f"call_{uuid.uuid4().hex[:24]}")
+    name: str
+    arguments: str
+    status: str = "completed"
+
+
+class ResponseUsage(BaseModel):
+    """Usage info for the Responses API."""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    output_tokens_details: dict[str, int] = Field(
+        default_factory=lambda: {"reasoning_tokens": 0}
+    )
+    total_tokens: int = 0
+
+
+class ResponseObject(BaseModel):
+    """The full response object returned by POST /v1/responses."""
+    id: str = Field(default_factory=lambda: f"resp_{uuid.uuid4().hex[:24]}")
+    object: str = "response"
+    created_at: int = Field(default_factory=lambda: int(time.time()))
+    status: str = "completed"
+    completed_at: Optional[int] = None
+    error: Optional[dict[str, Any]] = None
+    incomplete_details: Optional[dict[str, Any]] = None
+    instructions: Optional[str] = None
+    max_output_tokens: Optional[int] = None
+    model: str = "catgpt-browser"
+    output: List[Any] = Field(default_factory=list)
+    output_text: Optional[str] = None
+    parallel_tool_calls: bool = True
+    previous_response_id: Optional[str] = None
+    temperature: Optional[float] = 1.0
+    text: dict[str, Any] = Field(default_factory=lambda: {"format": {"type": "text"}})
+    tool_choice: Optional[Union[str, dict]] = "auto"
+    tools: List[Any] = Field(default_factory=list)
+    top_p: Optional[float] = 1.0
+    truncation: Optional[str] = "disabled"
+    usage: Optional[ResponseUsage] = None
+    user: Optional[str] = None
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -16,9 +16,9 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from src.browser.manager import BrowserManager
 from src.browser.auto_login import ensure_logged_in
@@ -106,38 +106,61 @@ app = FastAPI(
 )
 
 # ── Bearer Token Auth Middleware ────────────────────────────────
-class BearerTokenMiddleware(BaseHTTPMiddleware):
+class BearerTokenMiddleware:
     """
-    Require a Bearer token on all API requests when API_TOKEN is set.
+    Pure ASGI middleware for Bearer token auth.
+
+    Uses raw ASGI protocol instead of BaseHTTPMiddleware to avoid the
+    Python 3.9 event-loop mismatch bug that corrupts asyncio.Lock
+    when exceptions propagate through BaseHTTPMiddleware's task group.
+
     Skips auth for /docs, /openapi.json, and health-check paths.
     """
 
-    OPEN_PATHS = {"/docs", "/redoc", "/openapi.json", "/healthz"}
+    OPEN_PATHS = {b"/docs", b"/redoc", b"/openapi.json", b"/healthz"}
 
-    async def dispatch(self, request: Request, call_next):
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
         token = Config.API_TOKEN
         if not token:
-            # No token configured — auth disabled
-            return await call_next(request)
+            await self.app(scope, receive, send)
+            return
 
-        path = request.url.path
-        if path in self.OPEN_PATHS:
-            return await call_next(request)
+        path = scope.get("path", "").encode() if isinstance(scope.get("path"), str) else scope.get("raw_path", b"")
+        # Also check the string path for comparison
+        path_str = scope.get("path", "")
+        if path_str in {"/docs", "/redoc", "/openapi.json", "/healthz"}:
+            await self.app(scope, receive, send)
+            return
 
-        # Check Authorization header
-        auth_header = request.headers.get("authorization", "")
-        if auth_header.startswith("Bearer "):
-            provided = auth_header[7:]
-        else:
-            provided = ""
+        # Extract Authorization header
+        headers = dict(scope.get("headers", []))
+        auth_value = headers.get(b"authorization", b"").decode()
+
+        provided = ""
+        if auth_value.startswith("Bearer "):
+            provided = auth_value[7:]
 
         if provided != token:
-            return JSONResponse(
+            response = JSONResponse(
                 status_code=401,
-                content={"error": {"message": "Invalid or missing API token. Set Authorization: Bearer <API_TOKEN>", "type": "auth_error"}},
+                content={
+                    "error": {
+                        "message": "Invalid or missing API token. Set Authorization: Bearer <API_TOKEN>",
+                        "type": "auth_error",
+                    }
+                },
             )
+            await response(scope, receive, send)
+            return
 
-        return await call_next(request)
+        await self.app(scope, receive, send)
 
 
 app.add_middleware(BearerTokenMiddleware)

--- a/src/browser/human.py
+++ b/src/browser/human.py
@@ -28,20 +28,101 @@ async def random_delay(min_ms: int | None = None, max_ms: int | None = None) -> 
 
 async def human_type(page: Page, selector: str, text: str) -> None:
     """
-    Paste text all at once into the input field.
+    Insert text into a contenteditable input field.
 
-    Uses keyboard.insert_text() which behaves like a clipboard paste —
-    fast and reliable, avoids issues with per-character typing on
-    contenteditable divs.
+    Uses execCommand('insertText') which fires proper beforeinput/input
+    events that ProseMirror-based editors (like ChatGPT's) require.
+    Falls back to clipboard paste, then keyboard.insert_text().
     """
     element = page.locator(selector).first
     await element.click()
-    # Small pause after focusing (human would take a moment)
     await asyncio.sleep(random.uniform(0.1, 0.25))
 
-    log.debug(f"Pasting {len(text)} chars into {selector}")
+    # Clear any stale text in the input before inserting new text
+    try:
+        await page.evaluate(
+            """(selector) => {
+                const el = document.querySelector(selector);
+                if (el) {
+                    el.focus();
+                    // Select all existing text and delete it
+                    document.execCommand('selectAll', false, null);
+                    document.execCommand('delete', false, null);
+                }
+            }""",
+            selector,
+        )
+        await asyncio.sleep(0.05)
+    except Exception as e:
+        log.debug(f"Could not clear input: {e}")
+
+    log.debug(f"Inserting {len(text)} chars into {selector}")
+
+    # Strategy 1: execCommand — fires beforeinput + input events
+    try:
+        result = await page.evaluate(
+            """([selector, text]) => {
+                const el = document.querySelector(selector);
+                if (!el) return 'no-element';
+                el.focus();
+                const ok = document.execCommand('insertText', false, text);
+                return ok ? 'ok' : 'failed';
+            }""",
+            [selector, text],
+        )
+        if result == "ok":
+            log.debug("Insert via execCommand succeeded")
+            return
+        log.debug(f"execCommand result: {result}")
+    except Exception as e:
+        log.debug(f"execCommand failed: {e}")
+
+    # Strategy 2: Clipboard paste event
+    try:
+        result = await page.evaluate(
+            """([selector, text]) => {
+                const el = document.querySelector(selector);
+                if (!el) return 'no-element';
+                el.focus();
+                const dt = new DataTransfer();
+                dt.setData('text/plain', text);
+                const event = new ClipboardEvent('paste', {
+                    bubbles: true, cancelable: true, clipboardData: dt
+                });
+                el.dispatchEvent(event);
+                return 'ok';
+            }""",
+            [selector, text],
+        )
+        if result == "ok":
+            log.debug("Insert via paste event succeeded")
+            return
+    except Exception as e:
+        log.debug(f"Paste event failed: {e}")
+
+    # Strategy 3: keyboard.insert_text() — legacy fallback
+    log.debug("Falling back to keyboard.insert_text()")
     await page.keyboard.insert_text(text)
-    log.debug("Paste complete")
+    log.debug("insert_text complete")
+
+    # Verify text was actually inserted
+    await asyncio.sleep(0.1)
+    try:
+        actual = await page.evaluate(
+            """(selector) => {
+                const el = document.querySelector(selector);
+                return el ? (el.innerText || el.textContent || '').trim() : '';
+            }""",
+            selector,
+        )
+        if not actual:
+            log.warning(f"Text insertion verification failed — input appears empty after all strategies")
+        elif len(actual) < len(text) * 0.5:
+            log.warning(f"Text insertion may be partial — expected {len(text)} chars, got {len(actual)}")
+        else:
+            log.debug(f"Text insertion verified: {len(actual)} chars in input")
+    except Exception as e:
+        log.debug(f"Could not verify text insertion: {e}")
 
 
 async def human_click(page: Page, selector: str) -> None:

--- a/src/browser/manager.py
+++ b/src/browser/manager.py
@@ -23,16 +23,17 @@ log = setup_logging("browser")
 
 def _resolve_domains_for_chrome() -> str:
     """
-    Pre-resolve key domains and return a --host-resolver-rules string
-    for Chrome. This works around Chrome's built-in DNS resolver
-    failing inside Docker containers.
+    Pre-resolve key domains via the OS and return a --host-resolver-rules
+    string for Chrome.
 
-    Returns empty string if not running in Docker or all resolutions fail.
+    Chrome's built-in DNS client (even with --disable-features=AsyncDns)
+    is unreliable — it can return DNS_PROBE_FINISHED_NXDOMAIN for domains
+    that the OS resolver handles fine.  By pre-resolving here and passing
+    the IPs via --host-resolver-rules, Chrome bypasses its own resolver
+    entirely and the problem disappears.
+
+    Returns empty string if all resolutions fail.
     """
-    # Only needed in Docker (check for /.dockerenv or DISPLAY=:99)
-    if not os.path.exists("/.dockerenv") and os.environ.get("DISPLAY") != ":99":
-        return ""
-
     domains = [
         "chatgpt.com",
         "cdn.oaistatic.com",
@@ -77,22 +78,32 @@ def _cleanup_stale_locks(data_dir: Path) -> None:
     - *-journal, *-wal, *-shm — SQLite journal/WAL files that cause
       "database is locked" errors (UKM, Top Sites, History, etc.)
 
-    We also attempt to kill any orphan chrome-for-testing processes.
+    We also attempt to kill any orphan Chromium processes that are using
+    our user-data-dir.
     """
     import subprocess
 
-    # 1. Kill orphan chrome-for-testing processes FIRST
-    try:
-        result = subprocess.run(
-            ["pkill", "-f", "chrome-for-testing"],
-            capture_output=True, timeout=3
-        )
-        if result.returncode == 0:
-            log.info("Killed orphan chrome processes")
-            import time
-            time.sleep(1)
-    except Exception:
-        pass  # Non-critical
+    # 1. Kill orphan Chromium processes FIRST.
+    #    Match multiple patterns: the macOS app name has spaces ("Google Chrome
+    #    for Testing"), Linux uses lowercase hyphens ("chrome-for-testing"),
+    #    and generic "chromium" for bundled builds.
+    kill_patterns = [
+        "Google Chrome for Testing",
+        "chrome-for-testing",
+        "chromium",
+    ]
+    for pattern in kill_patterns:
+        try:
+            result = subprocess.run(
+                ["pkill", "-9", "-f", pattern],
+                capture_output=True, timeout=3
+            )
+            if result.returncode == 0:
+                log.info(f"Killed orphan browser processes matching '{pattern}'")
+                import time
+                time.sleep(1)
+        except Exception:
+            pass  # Non-critical
 
     # 2. Remove singleton lock files
     lock_files = ["SingletonLock", "SingletonSocket", "SingletonCookie"]
@@ -118,6 +129,54 @@ def _cleanup_stale_locks(data_dir: Path) -> None:
                 pass
     if removed:
         log.info(f"Removed {removed} stale SQLite journal/WAL/SHM files")
+
+    # 4. Clear ALL network / DNS / cache state that can corrupt Chrome's
+    #    resolver and cause DNS_PROBE_FINISHED_NXDOMAIN for every domain.
+    #    Chrome's built-in DNS client stores state in the persistent profile
+    #    that survives restarts and can poison resolution for ALL sites.
+    import shutil
+
+    # 4a. Delete network state files (DNS, QUIC, HTTP/3 connection cache)
+    network_files = [
+        "Default/Network Persistent State",
+        "Default/Network Action Predictor",
+        "Default/TransportSecurity",
+        "Default/Reporting and NEL",
+        "Default/SCT Auditing Pending Reports",
+        "Default/ServerCertificate",
+        "Default/DIPS",
+        "Default/Safe Browsing Cookies",
+    ]
+    for rel_path in network_files:
+        fpath = data_dir / rel_path
+        if fpath.exists():
+            try:
+                fpath.unlink()
+                log.info(f"Cleared network state: {rel_path}")
+            except Exception:
+                pass
+
+    # 4b. Delete cache directories (HTTP cache, compiled JS, GPU shaders).
+    #     These can grow large and contain stale connection/DNS info.
+    cache_dirs = [
+        "Default/Cache",
+        "Default/Code Cache",
+        "Default/GPUCache",
+        "Default/DawnGraphiteCache",
+        "Default/DawnWebGPUCache",
+        "Default/Service Worker",
+        "GrShaderCache",
+        "GraphiteDawnCache",
+        "ShaderCache",
+    ]
+    for rel_dir in cache_dirs:
+        dpath = data_dir / rel_dir
+        if dpath.exists() and dpath.is_dir():
+            try:
+                shutil.rmtree(dpath, ignore_errors=True)
+                log.info(f"Cleared cache directory: {rel_dir}")
+            except Exception:
+                pass
 
 
 class BrowserManager:
@@ -152,6 +211,12 @@ class BrowserManager:
             "--disable-blink-features=AutomationControlled",
             "--no-first-run",
             "--no-default-browser-check",
+            # Disable Chrome's built-in DNS client entirely.  Even with
+            # AsyncDns off, Chrome's stub resolver can return NXDOMAIN for
+            # domains the OS resolves fine.  We also pre-resolve domains
+            # via --host-resolver-rules (see _resolve_domains_for_chrome).
+            "--disable-features=AsyncDns,DnsOverHttps",
+            "--dns-prefetch-disable",
         ]
 
         # Docker-specific flags
@@ -162,8 +227,8 @@ class BrowserManager:
                 "--disable-gpu",
             ])
 
-        # In Docker, Chrome's DNS resolver can fail. Pre-resolve domains
-        # and pass them directly via --host-resolver-rules.
+        # Pre-resolve domains via the OS and hardcode the IPs for Chrome.
+        # This prevents Chrome's built-in DNS client from ever being used.
         resolver_rules = _resolve_domains_for_chrome()
         if resolver_rules:
             chrome_args.append(f"--host-resolver-rules={resolver_rules}")
@@ -200,8 +265,80 @@ class BrowserManager:
         else:
             self._page = await self._context.new_page()
 
+        # NOTE: We intentionally do NOT flush Chrome's DNS cache here.
+        # The --host-resolver-rules flag handles DNS resolution for all
+        # mapped domains.  Previously, _clear_dns_cache() would navigate
+        # to chrome://net-internals and flush the host cache + socket
+        # pools — but this destroyed working connection state and caused
+        # DNS_PROBE_FINISHED_NXDOMAIN on subsequent navigations.
+
         log.info(f"Browser ready — viewport {width}x{height}")
         return self._page
+
+    async def _clear_dns_cache(self) -> None:
+        """Clear Chrome's in-memory DNS host cache via chrome://net-internals."""
+        import asyncio as _asyncio
+
+        if self._page is None:
+            return
+
+        try:
+            await self._page.goto(
+                "chrome://net-internals/#dns",
+                wait_until="domcontentloaded",
+                timeout=10000,
+            )
+            await _asyncio.sleep(0.5)
+
+            # The "Clear host cache" button ID in chrome://net-internals/#dns
+            cleared = await self._page.evaluate(
+                """
+                () => {
+                    // Try the standard button
+                    const btn = document.getElementById('dns-view-clear-cache');
+                    if (btn) { btn.click(); return 'clicked-dns-view-clear-cache'; }
+                    // Newer Chrome: look for any button that says "Clear"
+                    const buttons = Array.from(document.querySelectorAll('button'));
+                    for (const b of buttons) {
+                        if (b.textContent.toLowerCase().includes('clear')) {
+                            b.click();
+                            return 'clicked-' + b.textContent.trim();
+                        }
+                    }
+                    return 'no-clear-button-found';
+                }
+                """
+            )
+            log.info(f"Chrome DNS cache flush: {cleared}")
+            await _asyncio.sleep(0.3)
+
+            # Also try to flush socket pools
+            try:
+                await self._page.goto(
+                    "chrome://net-internals/#sockets",
+                    wait_until="domcontentloaded",
+                    timeout=5000,
+                )
+                await _asyncio.sleep(0.3)
+                await self._page.evaluate(
+                    """
+                    () => {
+                        const buttons = Array.from(document.querySelectorAll('button'));
+                        for (const b of buttons) {
+                            if (b.textContent.toLowerCase().includes('flush') ||
+                                b.textContent.toLowerCase().includes('close')) {
+                                b.click();
+                            }
+                        }
+                    }
+                    """
+                )
+                log.info("Chrome socket pools flushed")
+            except Exception:
+                pass  # Best-effort
+
+        except Exception as e:
+            log.warning(f"Could not clear Chrome DNS cache: {e}")
 
     async def apply_stealth_patches(self) -> None:
         """
@@ -234,6 +371,78 @@ class BrowserManager:
         log.info(f"Navigating to {url}")
         await self.page.goto(url, wait_until="domcontentloaded")
         log.info("Page loaded")
+
+    async def recover_page(self) -> bool:
+        """Recover from DNS / page errors by re-navigating to ChatGPT.
+
+        Tries JS navigation first (avoids DNS lookup), then page.goto().
+        Returns True if recovery succeeded, False otherwise.
+        """
+        import asyncio as _asyncio
+
+        if self._page is None:
+            return False
+
+        # Strategy 1: JS navigation (doesn't go through Chrome's DNS resolver)
+        try:
+            log.info("Page recovery via JS navigation...")
+            await self._page.evaluate(f"window.location.href = '{Config.CHATGPT_URL}'")
+            await self._page.wait_for_load_state("domcontentloaded", timeout=15000)
+            await _asyncio.sleep(1)
+            error = await self._page.evaluate(
+                """
+                () => {
+                    const body = document.body ? document.body.innerText : '';
+                    if (body.includes('DNS_PROBE_FINISHED_NXDOMAIN')) return 'dns';
+                    if (body.includes('ERR_NAME_NOT_RESOLVED')) return 'dns';
+                    if (body.includes('ERR_CONNECTION_REFUSED')) return 'conn';
+                    return null;
+                }
+                """
+            )
+            if not error:
+                log.info("Page recovery succeeded (JS navigation)")
+                return True
+            log.warning(f"JS navigation recovery still shows error: {error}")
+        except Exception as e:
+            log.warning(f"JS navigation recovery failed: {e}")
+
+        # Strategy 2: page.goto() with retries
+        for attempt in range(1, 4):
+            try:
+                log.info(f"Page recovery attempt {attempt}/3 (page.goto)...")
+                await self._page.goto(
+                    Config.CHATGPT_URL,
+                    wait_until="domcontentloaded",
+                    timeout=30000,
+                )
+                await _asyncio.sleep(1)
+
+                error = await self._page.evaluate(
+                    """
+                    () => {
+                        const body = document.body ? document.body.innerText : '';
+                        if (body.includes('DNS_PROBE_FINISHED_NXDOMAIN')) return 'dns';
+                        if (body.includes('ERR_NAME_NOT_RESOLVED')) return 'dns';
+                        if (body.includes('ERR_CONNECTION_REFUSED')) return 'conn';
+                        return null;
+                    }
+                    """
+                )
+                if error:
+                    log.warning(f"Recovery attempt {attempt} still shows error: {error}")
+                    await _asyncio.sleep(attempt * 2)
+                    continue
+
+                log.info("Page recovery succeeded")
+                return True
+
+            except Exception as e:
+                log.warning(f"Recovery attempt {attempt} failed: {e}")
+                await _asyncio.sleep(attempt * 2)
+
+        log.error("Page recovery failed after all attempts")
+        return False
 
     async def is_logged_in(self) -> bool:
         """

--- a/src/chatgpt/client.py
+++ b/src/chatgpt/client.py
@@ -413,17 +413,14 @@ class ChatGPTClient:
     # ── Navigation ──────────────────────────────────────────────
 
     async def new_chat(self) -> None:
-        """Start a new conversation by navigating to the home page."""
-        log.info("Starting new chat...")
-        # Direct navigation is the most reliable way — avoids duplicate button issues
-        await self._page.goto(Config.CHATGPT_URL, wait_until="domcontentloaded")
-        await asyncio.sleep(3)
+        """Start a new conversation.
 
         Strategy order:
         1. SPA button click (avoids DNS issues, preserves browser state)
         2. JavaScript location change (no DNS lookup needed if page is loaded)
-        3. Full page.goto() (last resort — may fail with DNS errors)
+        3. Full page.goto() (last resort - may fail with DNS errors)
         """
+        log.info("Starting new chat...")
         # Already on a fresh chat — nothing to do
         if "chatgpt.com" in self._page.url:
             try:

--- a/src/chatgpt/client.py
+++ b/src/chatgpt/client.py
@@ -39,6 +39,60 @@ class ChatGPTClient:
 
     def __init__(self, page: Page) -> None:
         self._page = page
+        self._setup_network_logging()
+
+    def _setup_network_logging(self) -> None:
+        """Monitor network requests, WebSockets, and JS errors for debugging."""
+        # Only log important API calls at INFO; sentinel/ping/heartbeat at DEBUG
+        _important_paths = ("/f/conversation", "/conversations?", "/stream_status")
+
+        def on_request(request):
+            url = request.url
+            if "backend-api" in url:
+                if any(p in url for p in _important_paths):
+                    log.info(f"NET REQ: {request.method} {url[:200]}")
+                else:
+                    log.debug(f"NET REQ: {request.method} {url[:200]}")
+
+        async def on_response(response):
+            url = response.url
+            if "backend-api" in url:
+                if any(p in url for p in _important_paths):
+                    log.info(f"NET RESP: {response.status} {url[:200]}")
+                else:
+                    log.debug(f"NET RESP: {response.status} {url[:200]}")
+
+        def on_request_failed(request):
+            url = request.url
+            failure = request.failure or "unknown"
+            if "chrome-extension" not in url and "favicon" not in url:
+                # Patchright internal injection is expected to fail
+                if "patchright" in url:
+                    log.debug(f"NET FAIL: {url[:150]} — {failure}")
+                else:
+                    log.warning(f"NET FAIL: {url[:150]} — {failure}")
+
+        def on_console(msg):
+            if msg.type == "error":
+                log.info(f"JS ERROR: {msg.text[:300]}")
+            elif msg.type == "warning":
+                log.debug(f"JS WARNING: {msg.text[:300]}")
+
+        def on_page_error(error):
+            log.error(f"JS PAGE ERROR: {error}")
+
+        def on_websocket(ws):
+            log.debug(f"WS OPEN: {ws.url[:200]}")
+            ws.on("framereceived", lambda payload: log.debug(f"WS RECV: {str(payload)[:200]}"))
+            ws.on("framesent", lambda payload: log.debug(f"WS SEND: {str(payload)[:200]}"))
+            ws.on("close", lambda _: log.debug(f"WS CLOSE: {ws.url[:200]}"))
+
+        self._page.on("request", on_request)
+        self._page.on("response", on_response)
+        self._page.on("requestfailed", on_request_failed)
+        self._page.on("console", on_console)
+        self._page.on("pageerror", on_page_error)
+        self._page.on("websocket", on_websocket)
 
     @property
     def page(self) -> Page:
@@ -70,36 +124,62 @@ class ChatGPTClient:
         log.info(f"Sending message ({len(text)} chars, {len(all_attachments)} attachments): {text[:80]}...")
         start_time = time.time()
 
-        # 0. Count existing assistant messages so we know when a new one appears
+        # 0. Check page health — recover from DNS errors before trying to send
+        page_error = await self._detect_page_error()
+        if page_error:
+            log.warning(f"Page error detected before send: {page_error}")
+            raise RuntimeError(f"Page is in error state: {page_error}")
+
+        # 0.5 Count existing assistant messages so we know when a new one appears
         pre_count = await count_assistant_messages(self._page)
         pre_turn_signature = await get_latest_assistant_turn_signature(self._page)
         log.debug(f"Assistant messages before send: {pre_count}")
         log.debug(f"Latest assistant turn before send: {pre_turn_signature}")
 
+        # 0.5 Check for and dismiss any blocking dialogs/overlays
+        await self._dismiss_overlays()
+
         # 1. Brief pause (human would take a moment to start typing)
-        await random_delay(250, 700)
+        await random_delay(100, 300)
 
         # 1.5. Upload files/images if provided
         if all_attachments:
             await self._upload_files(all_attachments)
 
-        # 2. Find the chat input
+        # 2. Find the chat input (retry once after dismissing overlays if not found)
         input_selector = await self._find_selector(Selectors.CHAT_INPUT, "chat input")
+        if not input_selector:
+            # An overlay may have blocked it — dismiss and retry
+            log.info("Chat input not found on first try, dismissing overlays and retrying...")
+            await self._dismiss_overlays()
+            await asyncio.sleep(1)
+            input_selector = await self._find_selector(Selectors.CHAT_INPUT, "chat input")
         if not input_selector:
             raise RuntimeError("Could not find chat input element")
 
         # 3. Paste the message (all at once)
         await human_type(self._page, input_selector, text)
 
-        # Small pause after pasting (like a human reviewing before send)
-        await random_delay(150, 350)
+        # 4. Poll briefly for auto-submit (execCommand can trigger
+        #    f/conversation automatically in the current frontend).
+        #    If a new assistant turn appeared, skip the send button click.
+        auto_submitted = False
+        for _ in range(6):  # poll up to ~3s in 0.5s intervals
+            await asyncio.sleep(0.5)
+            post_count = await count_assistant_messages(self._page)
+            if post_count > pre_count:
+                auto_submitted = True
+                break
 
-        # 4. Send the message
-        sent = await self._click_send()
-        if not sent:
-            # Fallback: try pressing Enter
-            log.info("Send button not found, trying Enter key")
-            await self._page.keyboard.press("Enter")
+        if auto_submitted:
+            log.info("ChatGPT auto-submitted after text entry — skipping send button click")
+        else:
+            # No auto-submit — click the send button
+            log.info("No auto-submit detected, clicking send button")
+            sent = await self._click_send()
+            if not sent:
+                log.info("Send button not found, trying Enter key")
+                await self._page.keyboard.press("Enter")
 
         # 5. Wait for response with message count awareness
         log.info("Waiting for ChatGPT response...")
@@ -114,7 +194,7 @@ class ChatGPTClient:
             log.warning("Response may not be complete (timeout)")
 
         # Small buffer after completion to let DOM settle
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(0.2)
 
         # 6. Check for generated images in the response FIRST
         #    (image turns have no copy button, so we must detect images
@@ -137,12 +217,25 @@ class ChatGPTClient:
                 previous_turn_signature=pre_turn_signature,
             )
 
+            # If extraction returned empty, retry a few times (DOM may not be settled)
+            if not response_text.strip():
+                log.warning("Empty response extracted — retrying after short wait")
+                for retry in range(1, 4):
+                    await asyncio.sleep(1.5 * retry)
+                    response_text = await extract_last_response_via_copy(
+                        self._page,
+                        previous_turn_signature=pre_turn_signature,
+                    )
+                    if response_text.strip():
+                        log.info(f"Got response on extraction retry {retry}")
+                        break
+
             # If we only captured a transient status (e.g. "Pro thinking"),
             # keep waiting and retry extraction on the same new turn.
             if is_incomplete_response_text(response_text):
                 log.warning("Extracted text looks incomplete/transient; retrying for final answer")
                 for attempt in range(1, 3):
-                    await asyncio.sleep(4)
+                    await asyncio.sleep(2)
                     await wait_for_response_complete(
                         self._page,
                         timeout_ms=90000,
@@ -182,23 +275,123 @@ class ChatGPTClient:
     # ── Navigation ──────────────────────────────────────────────
 
     async def new_chat(self) -> None:
-        """Start a new conversation by navigating to the home page."""
-        log.info("Starting new chat...")
-        # Direct navigation is the most reliable way — avoids duplicate button issues
-        await self._page.goto(Config.CHATGPT_URL, wait_until="domcontentloaded")
-        await asyncio.sleep(1.5)
+        """Start a new conversation.
 
-        # Wait for the chat input to be visible (signals page is ready)
+        Strategy order:
+        1. SPA button click (avoids DNS issues, preserves browser state)
+        2. JavaScript location change (no DNS lookup needed if page is loaded)
+        3. Full page.goto() (last resort — may fail with DNS errors)
+        """
+        # Already on a fresh chat — nothing to do
+        if "chatgpt.com" in self._page.url:
+            try:
+                turn_count = await self._page.evaluate(
+                    "document.querySelectorAll('[data-testid^=\"conversation-turn-\"]').length"
+                )
+                if turn_count == 0:
+                    log.info("Already on a fresh chat — skipping navigation")
+                    return
+            except Exception:
+                pass
+
+        # Strategy 1: SPA button click
+        for selector in Selectors.NEW_CHAT_BUTTON:
+            try:
+                btn = await self._page.query_selector(selector)
+                if btn and await btn.is_visible():
+                    await btn.click()
+                    log.info(f"New chat via SPA button: {selector}")
+                    await asyncio.sleep(1)
+                    # Verify we're on a fresh chat
+                    try:
+                        turn_count = await self._page.evaluate(
+                            "document.querySelectorAll('[data-testid^=\"conversation-turn-\"]').length"
+                        )
+                        if turn_count == 0:
+                            await self._wait_for_chat_input()
+                            return
+                    except Exception:
+                        pass
+            except Exception:
+                continue
+
+        # Strategy 2: JavaScript navigation (avoids DNS lookup)
+        try:
+            log.info("New chat via JS navigation...")
+            await self._page.evaluate("window.location.href = '/'")
+            await self._page.wait_for_load_state("domcontentloaded", timeout=15000)
+            page_error = await self._detect_page_error()
+            if not page_error:
+                log.info("New chat started (JS navigation)")
+                await self._wait_for_chat_input()
+                return
+        except Exception as e:
+            log.warning(f"JS navigation failed: {e}")
+
+        # Strategy 3: Full page.goto() — last resort
+        max_attempts = 3
+        for attempt in range(1, max_attempts + 1):
+            log.info(f"New chat via page.goto (attempt {attempt}/{max_attempts})...")
+            try:
+                await self._page.goto(
+                    Config.CHATGPT_URL,
+                    wait_until="domcontentloaded",
+                    timeout=30000,
+                )
+            except Exception as e:
+                log.warning(f"page.goto failed (attempt {attempt}): {e}")
+                if attempt < max_attempts:
+                    await asyncio.sleep(attempt * 3)
+                    continue
+                raise
+
+            page_error = await self._detect_page_error()
+            if page_error:
+                log.error(f"Page error after goto (attempt {attempt}): {page_error}")
+                if attempt < max_attempts:
+                    await asyncio.sleep(attempt * 3)
+                    continue
+                raise RuntimeError(f"Page error persists after {max_attempts} attempts: {page_error}")
+
+            log.info("New chat started (page.goto)")
+            await self._wait_for_chat_input()
+            return
+
+    async def _wait_for_chat_input(self) -> None:
+        """Wait for the chat input to become visible and interactive."""
         for selector in Selectors.CHAT_INPUT:
             try:
                 await self._page.wait_for_selector(selector, timeout=10000, state="visible")
                 log.debug(f"Chat input ready: {selector}")
-                break
+                # Brief settle for React handlers to attach
+                await asyncio.sleep(0.5)
+                return
             except Exception:
                 continue
+        log.warning("Chat input not found — page may not be fully ready")
 
-        await random_delay(300, 600)
-        log.info("New chat started (navigated to home)")
+    async def _detect_page_error(self) -> str | None:
+        """Check if the current page shows a browser or ChatGPT error."""
+        try:
+            return await self._page.evaluate(
+                """
+                () => {
+                    const body = document.body ? document.body.innerText : '';
+                    const title = document.title || '';
+                    if (body.includes('DNS_PROBE_FINISHED_NXDOMAIN')) return 'DNS_PROBE_FINISHED_NXDOMAIN';
+                    if (body.includes('ERR_NAME_NOT_RESOLVED')) return 'ERR_NAME_NOT_RESOLVED';
+                    if (body.includes('ERR_CONNECTION_REFUSED')) return 'ERR_CONNECTION_REFUSED';
+                    if (body.includes('ERR_INTERNET_DISCONNECTED')) return 'ERR_INTERNET_DISCONNECTED';
+                    if (body.includes('ERR_CONNECTION_TIMED_OUT')) return 'ERR_CONNECTION_TIMED_OUT';
+                    if (title.includes("can't be reached") || title.includes("is not available"))
+                        return 'page_unreachable';
+                    if (body.includes('Something went wrong')) return 'ChatGPT_error';
+                    return null;
+                }
+                """
+            )
+        except Exception:
+            return None
 
     async def navigate_to_thread(self, thread_id: str) -> None:
         """Navigate to an existing conversation thread."""
@@ -321,12 +514,98 @@ class ChatGPTClient:
         log.warning(f"No working selector found for: {name}")
         return None
 
+    async def _dismiss_overlays(self) -> None:
+        """Check for and dismiss any blocking dialogs/overlays on the page."""
+        try:
+            result = await self._page.evaluate(
+                """
+                () => {
+                    const info = { dismissed: [], found: [] };
+
+                    // Check for role="dialog" overlays
+                    const dialogs = document.querySelectorAll('[role="dialog"], [role="alertdialog"], dialog[open]');
+                    for (const d of dialogs) {
+                        const text = (d.innerText || '').trim().substring(0, 200);
+                        info.found.push('dialog: ' + text);
+
+                        // Try to find and click dismiss/close buttons
+                        const closeBtn = d.querySelector(
+                            'button[aria-label="Close"], button[aria-label="Dismiss"], ' +
+                            'button:has(svg[data-testid="close"]), button.close'
+                        );
+                        if (closeBtn) {
+                            closeBtn.click();
+                            info.dismissed.push('dialog-close');
+                        }
+                    }
+
+                    // Check for "Continue generating" button
+                    const allButtons = document.querySelectorAll('button');
+                    for (const btn of allButtons) {
+                        const btnText = (btn.innerText || '').trim().toLowerCase();
+                        if (btnText.includes('continue generating')) {
+                            btn.click();
+                            info.dismissed.push('continue-generating');
+                        }
+                    }
+
+                    // Check for rate limit or error banners
+                    const banners = document.querySelectorAll('[class*="banner"], [class*="toast"], [class*="alert"]');
+                    for (const b of banners) {
+                        const text = (b.innerText || '').trim().substring(0, 200);
+                        if (text) info.found.push('banner: ' + text);
+                    }
+
+                    return info;
+                }
+                """
+            )
+            if result and isinstance(result, dict):
+                if result.get("dismissed"):
+                    log.info(f"Dismissed overlays: {result['dismissed']}")
+                if result.get("found"):
+                    log.debug(f"Page overlays found: {result['found']}")
+        except Exception as e:
+            log.debug(f"Overlay check failed: {e}")
+
     async def _click_send(self) -> bool:
         """Try to click the send button using selector fallbacks."""
+        # Check send button state before clicking
+        btn_state = await self._page.evaluate(
+            """
+            () => {
+                const selectors = [
+                    'button[data-testid="send-button"]',
+                    '#composer-submit-button',
+                    "button[aria-label='Send prompt']",
+                ];
+                for (const sel of selectors) {
+                    const btn = document.querySelector(sel);
+                    if (btn) {
+                        return {
+                            selector: sel,
+                            disabled: btn.disabled,
+                            ariaDisabled: btn.getAttribute('aria-disabled'),
+                            visible: btn.offsetParent !== null,
+                            classes: btn.className.substring(0, 100),
+                        };
+                    }
+                }
+                return null;
+            }
+            """
+        )
+        log.debug(f"Send button state: {btn_state}")
+
+        # Don't click a disabled send button — the input wasn't recognized
+        if isinstance(btn_state, dict) and btn_state.get("disabled"):
+            log.warning("Send button is disabled — text may not have been inserted properly")
+            return False
+
         selector = await self._find_selector(Selectors.SEND_BUTTON, "send button")
         if selector:
             await human_click(self._page, selector)
-            log.debug("Send button clicked")
+            log.info(f"Send button clicked via: {selector}")
             return True
         return False
 

--- a/src/chatgpt/detector.py
+++ b/src/chatgpt/detector.py
@@ -12,6 +12,7 @@ import asyncio
 import re
 
 from patchright.async_api import Page
+from patchright._impl._errors import TargetClosedError
 
 from src.selectors import Selectors
 from src.browser.human import idle_mouse_movement
@@ -67,6 +68,35 @@ def _empty_snapshot() -> dict:
         "hasImage": False,
         "text": "",
     }
+
+
+async def _dump_all_turns(page: Page) -> list[dict]:
+    """Dump info about all conversation turns for debugging."""
+    try:
+        turns = await page.evaluate(
+            """
+            () => {
+                const turns = Array.from(document.querySelectorAll('section[data-testid^="conversation-turn-"]'));
+                return turns.map((turn, idx) => {
+                    const role = turn.getAttribute('data-turn') || 'unknown';
+                    const testid = turn.getAttribute('data-testid') || '';
+                    const turnId = turn.getAttribute('data-turn-id') || '';
+                    const text = (turn.innerText || '').trim().substring(0, 100);
+                    const buttons = turn.querySelectorAll('button').length;
+                    const copyBtn = Boolean(turn.querySelector(
+                        'button[data-testid="copy-turn-action-button"], button[aria-label="Copy message"], button[aria-label="Copy"]'
+                    ));
+                    const hasArticle = Boolean(turn.querySelector('article'));
+                    const childTags = Array.from(turn.children).map(c => c.tagName).join(',');
+                    return { idx, role, testid, turnId, text, buttons, copyBtn, hasArticle, childTags };
+                });
+            }
+            """
+        )
+        return turns or []
+    except Exception as e:
+        log.debug(f"_dump_all_turns failed: {e}")
+        return []
 
 
 async def _latest_assistant_turn_snapshot(page: Page) -> dict:
@@ -256,7 +286,7 @@ async def wait_for_response_complete(
             waited += 500
 
     log.debug("Waiting for copy button or image on latest assistant turn...")
-    completed = await _wait_for_copy_button_or_image(page, pre_copy_count, timeout, previous_turn_signature)
+    completed = await _wait_for_copy_button_or_image(page, timeout, previous_turn_signature)
     if completed == "copy":
         log.info("Response complete — copy button appeared on latest turn")
         return True
@@ -280,9 +310,37 @@ async def wait_for_response_complete(
         return False
 
 
+async def _check_page_error(page: Page) -> str | None:
+    """Check if the page is showing an error state (DNS failure, crash, etc.).
+
+    Returns error description string if an error is detected, None otherwise.
+    """
+    try:
+        error = await page.evaluate(
+            """
+            () => {
+                // Chrome error pages
+                const body = document.body ? document.body.innerText : '';
+                if (body.includes('DNS_PROBE_FINISHED_NXDOMAIN')) return 'DNS_PROBE_FINISHED_NXDOMAIN';
+                if (body.includes('ERR_NAME_NOT_RESOLVED')) return 'ERR_NAME_NOT_RESOLVED';
+                if (body.includes('ERR_CONNECTION_REFUSED')) return 'ERR_CONNECTION_REFUSED';
+                if (body.includes('ERR_INTERNET_DISCONNECTED')) return 'ERR_INTERNET_DISCONNECTED';
+                if (body.includes('ERR_CONNECTION_TIMED_OUT')) return 'ERR_CONNECTION_TIMED_OUT';
+                // ChatGPT error states
+                if (body.includes('Something went wrong')) return 'ChatGPT_something_went_wrong';
+                if (body.includes("We're experiencing high demand")) return 'ChatGPT_high_demand';
+                if (document.title && document.title.includes('is not available')) return 'page_not_available';
+                return null;
+            }
+            """
+        )
+        return error
+    except Exception:
+        return None
+
+
 async def _wait_for_copy_button_or_image(
     page: Page,
-    pre_count: int,
     timeout_ms: int,
     previous_turn_signature: str | None = None,
 ) -> str | None:
@@ -294,34 +352,83 @@ async def _wait_for_copy_button_or_image(
     elapsed = 0
     poll_interval = Config.POLL_INTERVAL_MS / 1000
     heartbeat = 10
+    next_heartbeat = heartbeat
+    first_snapshot_logged = False
 
     while elapsed * 1000 < timeout_ms:
-        snapshot = await _latest_assistant_turn_snapshot(page)
+        try:
+            snapshot = await _latest_assistant_turn_snapshot(page)
+        except TargetClosedError:
+            log.error("Page/browser closed while waiting for response")
+            return None
+        except Exception as e:
+            log.warning(f"Snapshot failed ({type(e).__name__}): {e}")
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+            continue
+
         signature = snapshot.get("signature")
         is_new_turn = previous_turn_signature is None or (
             isinstance(signature, str) and signature != previous_turn_signature
         )
 
-        if is_new_turn and snapshot.get("hasCopyButton"):
-            current_count = await _count_copy_buttons(page)
+        # Log the first snapshot for diagnostics
+        if not first_snapshot_logged and elapsed >= 2:
+            first_snapshot_logged = True
+            turn_text = (snapshot.get("text") or "")[:200]
+            all_turns = await _dump_all_turns(page)
             log.debug(
-                f"Copy button detected on latest turn {signature} "
-                f"(copy-buttons: {pre_count} -> {current_count})"
+                f"First snapshot at {int(elapsed)}s | "
+                f"prev_sig={previous_turn_signature} cur_sig={signature} "
+                f"is_new={is_new_turn} copy={snapshot.get('hasCopyButton')} "
+                f"text[:{len(turn_text)}]={turn_text!r}"
+            )
+            log.debug(f"All turns ({len(all_turns)}): {all_turns}")
+
+        if is_new_turn and snapshot.get("hasCopyButton"):
+            log.info(
+                f"Copy button detected on latest turn {signature}"
             )
             return "copy"
 
-        has_image = await _detect_image_in_latest_turn(page, previous_turn_signature)
-        if has_image:
-            await asyncio.sleep(1.0)
-            log.debug(f"Generated image detected on latest turn {signature}")
+        # Use snapshot data directly instead of a separate evaluate call
+        if is_new_turn and snapshot.get("hasImage"):
+            await asyncio.sleep(0.5)
+            log.info(f"Generated image detected on latest turn {signature}")
             return "image"
 
-        if elapsed > 0 and elapsed % heartbeat == 0:
-            log.debug(f"Still waiting for copy button or image... ({int(elapsed)}s)")
+        if elapsed >= next_heartbeat:
+            next_heartbeat = elapsed + heartbeat
+            # Diagnostic: log what we see on the latest assistant turn
+            turn_text = (snapshot.get("text") or "")[:200]
+            log.debug(
+                f"Still waiting for copy/image... ({int(elapsed)}s) | "
+                f"sig={signature} is_new={is_new_turn} "
+                f"copy={snapshot.get('hasCopyButton')} "
+                f"text[:{len(turn_text)}]={turn_text!r}"
+            )
+
+            # Dump all turn info for debugging
+            all_turns = await _dump_all_turns(page)
+            log.debug(f"All turns: {all_turns}")
+
             await idle_mouse_movement(page)
+
+            # Check for page-level errors every heartbeat to fail fast
+            page_error = await _check_page_error(page)
+            if page_error:
+                log.error(f"Page error detected while waiting: {page_error}")
+                return None
 
         await asyncio.sleep(poll_interval)
         elapsed += poll_interval
+
+    # Diagnostic: save screenshot on timeout
+    try:
+        await page.screenshot(path="logs/detector_timeout.png")
+        log.info("Saved timeout screenshot to logs/detector_timeout.png")
+    except Exception as e:
+        log.debug(f"Could not save timeout screenshot: {e}")
 
     log.warning(f"Neither copy button nor image found after {int(elapsed)}s")
     return None
@@ -470,7 +577,7 @@ async def extract_last_response_via_copy(
         )
 
         if isinstance(click_result, dict) and click_result.get("clicked"):
-            await asyncio.sleep(0.8)
+            await asyncio.sleep(0.3)
             content = await page.evaluate("navigator.clipboard.readText().catch(() => '')")
             if content and content.strip() and content.strip() != str(pre_clipboard).strip():
                 log.info(

--- a/src/config.py
+++ b/src/config.py
@@ -36,7 +36,7 @@ class Config:
 
     # Browser
     HEADLESS: bool = os.getenv("HEADLESS", "false").lower() == "true"
-    SLOW_MO: int = int(os.getenv("SLOW_MO", "50"))
+    SLOW_MO: int = int(os.getenv("SLOW_MO", "25"))
     CHATGPT_URL: str = os.getenv("CHATGPT_URL", "https://chatgpt.com")
     CLAUDE_URL: str = os.getenv("CLAUDE_URL", "https://claude.ai")
 
@@ -60,7 +60,7 @@ class Config:
     THINKING_PAUSE_MIN: int = int(os.getenv("THINKING_PAUSE_MIN", "500"))
     THINKING_PAUSE_MAX: int = int(os.getenv("THINKING_PAUSE_MAX", "1500"))
     # Completion poll interval — how often to check if response is ready (ms)
-    POLL_INTERVAL_MS: int = int(os.getenv("POLL_INTERVAL_MS", "500"))
+    POLL_INTERVAL_MS: int = int(os.getenv("POLL_INTERVAL_MS", "300"))
 
     # Logging
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "DEBUG")

--- a/tests/test_openai_routes_helpers.py
+++ b/tests/test_openai_routes_helpers.py
@@ -27,6 +27,16 @@ if "patchright" not in sys.modules:
     sys.modules["patchright"] = patchright_mod
     sys.modules["patchright.async_api"] = async_api_mod
 
+    impl_mod = types.ModuleType("patchright._impl")
+    errors_mod = types.ModuleType("patchright._impl._errors")
+
+    class TargetClosedError(Exception):
+        pass
+
+    errors_mod.TargetClosedError = TargetClosedError
+    sys.modules["patchright._impl"] = impl_mod
+    sys.modules["patchright._impl._errors"] = errors_mod
+
 if "playwright_stealth" not in sys.modules:
     playwright_stealth_mod = types.ModuleType("playwright_stealth")
 
@@ -39,6 +49,7 @@ if "playwright_stealth" not in sys.modules:
 from src.api.openai_routes import (
     _build_page_extraction_note,
     _build_page_extraction_response_format,
+    _chat_completion_sse_chunk,
     _detect_user_prefix_contract,
     _display_app_name,
     _derive_app_key,
@@ -90,6 +101,16 @@ def _make_request(headers: dict[str, str] | None = None, client_host: str = "127
         "query_string": b"",
     }
     return Request(scope)
+
+
+async def _collect_stream(stream_response) -> list[bytes]:
+    chunks: list[bytes] = []
+    async for chunk in stream_response.body_iterator:
+        if isinstance(chunk, bytes):
+            chunks.append(chunk)
+        else:
+            chunks.append(chunk.encode("utf-8"))
+    return chunks
 
 
 class OpenAIRoutesHelpersTests(unittest.TestCase):
@@ -364,16 +385,34 @@ class ResponsesAPITests(unittest.TestCase):
         self.assertEqual(len(chat_req.tools), 1)
         self.assertEqual(chat_req.tool_choice, "auto")
 
-    def test_responses_request_to_chat_request_rejects_stream(self) -> None:
-        """Stream=true raises HTTPException."""
+    def test_validate_chat_request_accepts_stream(self) -> None:
+        """Stream=true is allowed; route handlers emit pseudo-SSE after completion."""
+        req = ChatCompletionRequest(
+            model="catgpt-browser",
+            messages=[ChatMessage(role="user", content="hello")],
+            stream=True,
+        )
+        _validate_chat_request(req)
+
+    def test_chat_completion_sse_chunk_uses_openai_shape(self) -> None:
+        response = ChatCompletionResponse(
+            model="catgpt-browser",
+            choices=[Choice(message=ChoiceMessage(role="assistant", content="ok"))],
+            usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+        chunk = _chat_completion_sse_chunk(response, {"content": "ok"})
+        self.assertIn('"object":"chat.completion.chunk"', chunk.replace(" ", ""))
+        self.assertIn('"content":"ok"', chunk.replace(" ", ""))
+
+    def test_responses_request_to_chat_request_preserves_stream_flag(self) -> None:
+        """Responses stream flag is forwarded for route-level SSE handling."""
         req = ResponsesRequest(
             model="catgpt-browser",
             input="Hello",
             stream=True,
         )
-        with self.assertRaises(HTTPException) as ctx:
-            _validate_responses_request(req)
-        self.assertEqual(ctx.exception.status_code, 400)
+        chat_req = _responses_request_to_chat_request(req)
+        self.assertTrue(chat_req.stream)
 
     def test_responses_response_from_chat_converts_content(self) -> None:
         """Chat completion response converts to Responses API format."""
@@ -456,6 +495,44 @@ class ResponsesAPITests(unittest.TestCase):
 
         self.assertEqual(captured["app_key_override"], "endpoint:n8n")
         self.assertEqual(resp.output[0].content[0].text, "ok")
+
+    def test_execute_chat_streaming_uses_non_stream_browser_call(self) -> None:
+        """Chat stream requests execute the browser call without stream=true."""
+        captured: dict[str, bool] = {}
+
+        async def fake_execute_chat_completion(
+            request: ChatCompletionRequest,
+            app_key_override: str = "",
+        ) -> ChatCompletionResponse:
+            captured["stream"] = bool(request.stream)
+            return ChatCompletionResponse(
+                model=request.model,
+                choices=[Choice(message=ChoiceMessage(role="assistant", content="ok"))],
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+
+        original = openai_routes_module._execute_chat_completion
+        openai_routes_module._execute_chat_completion = fake_execute_chat_completion
+        try:
+            req = ChatCompletionRequest(
+                model="catgpt-browser",
+                messages=[ChatMessage(role="user", content="Hello")],
+                stream=True,
+            )
+            _validate_chat_request(req)
+
+            async def _run_stream_test() -> bytes:
+                stream_response = await openai_routes_module._stream_chat_completion(req)
+                chunks = await _collect_stream(stream_response)
+                return b"".join(chunks)
+
+            body = asyncio.run(_run_stream_test())
+        finally:
+            openai_routes_module._execute_chat_completion = original
+
+        self.assertFalse(captured["stream"])
+        self.assertIn(b"chat.completion.chunk", body)
+        self.assertIn(b"[DONE]", body)
 
     def test_execute_responses_accepts_streaming_clients_without_streaming_browser(self) -> None:
         """Responses stream requests are executed as non-stream browser calls."""


### PR DESCRIPTION
This pull request adds three new diagnostic scripts to the `scripts` directory to help debug and analyze issues with ChatGPT's frontend, especially focusing on failures when sending a second message. These scripts use Playwright to automate the browser, inspect page state, capture errors, and simulate user actions. The scripts provide comprehensive diagnostics for frontend errors, backend responses, and JavaScript console issues.

The most important changes are:

**Diagnostic and Debugging Scripts:**

* Added `diagnose_chatgpt.py`: Automates a full end-to-end test of sending two messages in a fresh ChatGPT conversation, checking for error states, overlays, network status, and response presence after each message, with detailed page state dumps if failures occur.
* Added `test_console_errors.py`: Captures and reports JavaScript console errors and warnings, as well as uncaught exceptions, during the process of sending two messages in ChatGPT, to help identify frontend issues that prevent message sending or response rendering.
* Added `check_page_state.py`: Provides a quick diagnostic dump of the current ChatGPT page state, listing all conversation turns, their roles, text previews, button counts, and the presence of copy buttons.