### PR TITLE
feat(model-switch): add support for configurable model settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,9 @@ model id like `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`
 `gpt-4.5`, `gpt-4.1`, `gpt-4.1-mini`, or `gpt-4o`, CatGPT will try to switch
 the ChatGPT web UI to that model before sending the prompt. Current ChatGPT
 Plus composer labels map `gpt-5.5` to `Instant` and `gpt-5.5-thinking` to
-`Thinking`. If you want `catgpt-browser` itself to auto-switch, set
+`Thinking`. `gpt-5.5-thinking` and `gpt-5.5-pro` can also select the picker row
+setting shown beside `Thinking` and `Pro`; set `CHATGPT_MODEL_SETTINGS` to map
+those ids to `Standard` or `Extended`. If you want `catgpt-browser` itself to auto-switch, set
 `CHATGPT_DEFAULT_MODEL` to one of the configured ids. If the requested model is
 configured but not visible in your ChatGPT account's picker, CatGPT logs the
 visible picker labels and continues with the currently selected browser model
@@ -740,9 +742,11 @@ All settings are loaded from environment variables (`.env` file or `docker-compo
 | `IMAGES_DIR`         | `downloads/images`    | DALL-E image download directory                          |
 | `HEADLESS`           | `false`               | Run browser headless (not recommended — easily detected) |
 | `SLOW_MO`            | `0`                   | Playwright slow-motion delay (ms) for debugging          |
+| `BROWSER_CHANNEL`    | `chrome`              | Browser channel; use `chromium` to force bundled Chromium |
 | `CHATGPT_URL`        | `https://chatgpt.com` | Target ChatGPT URL                                       |
 | `CHATGPT_DEFAULT_MODEL` | ``                  | Optional model id to auto-apply when requests use `catgpt-browser` |
 | `CHATGPT_MODEL_ALIASES` | `gpt-5.5=Instant,...` | Comma-separated `public_id=UI label` map for browser model switching |
+| `CHATGPT_MODEL_SETTINGS` | `gpt-5.5-thinking=Standard,...` | Comma-separated model setting map for configurable picker rows like `Thinking` and `Pro` |
 | `CHATGPT_MODEL_SWITCH_TIMEOUT` | `10000`     | Max wait time (ms) to confirm the ChatGPT UI switched models |
 | `CHATGPT_MODEL_SWITCH_STRICT` | `false`      | If `true`, return an error when a requested ChatGPT UI model cannot be selected |
 | `ATTACHMENT_EXPAND_MULTIPAGE` | `true`      | If `true`, expands multi-page PDFs and multi-frame images into ordered page images before upload |

--- a/docs/MODEL_SWITCHING.md
+++ b/docs/MODEL_SWITCHING.md
@@ -47,6 +47,17 @@ Format:
 public_id=Primary UI Label|Alternate UI Label|Another Alternate
 ```
 
+`CHATGPT_MODEL_SETTINGS` maps model ids or UI labels to the extra setting shown
+beside configurable picker rows such as `Thinking` and `Pro`:
+
+```env
+CHATGPT_MODEL_SETTINGS=gpt-5.5-thinking=Extended,gpt-5.5-pro=Standard
+```
+
+The default configuration exposes both `gpt-5.5-thinking` and `gpt-5.5-pro`,
+with both set to `Standard`. Use `Standard` or `Extended` exactly as shown in
+the ChatGPT picker.
+
 If a request uses `catgpt-browser`, CatGPT keeps the current browser-selected
 model unless `CHATGPT_DEFAULT_MODEL` is set:
 

--- a/src/browser/manager.py
+++ b/src/browser/manager.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import datetime
 import os
+import platform
 import random
 import socket
 from pathlib import Path
@@ -19,6 +20,13 @@ from src.browser.stealth import apply_stealth
 from src.log import setup_logging
 
 log = setup_logging("browser")
+
+
+def _is_docker_runtime() -> bool:
+    """Return whether Chrome is running inside the Docker/Xvfb environment."""
+    if os.path.exists("/.dockerenv"):
+        return True
+    return platform.system() != "Windows" and os.environ.get("DISPLAY") == ":99"
 
 
 def _resolve_domains_for_chrome() -> str:
@@ -34,8 +42,8 @@ def _resolve_domains_for_chrome() -> str:
 
     Returns empty string if all resolutions fail.
     """
-    # Only needed in Docker (check for /.dockerenv or DISPLAY=:99)
-    if not os.path.exists("/.dockerenv") and os.environ.get("DISPLAY") != ":99":
+    # Only needed in Docker (check for /.dockerenv or DISPLAY=:99).
+    if not _is_docker_runtime():
         return ""
 
     common_domains = [
@@ -222,7 +230,7 @@ class BrowserManager:
         log.info("Launching browser...")
         self._playwright = await async_playwright().start()
 
-        in_docker = os.path.exists("/.dockerenv") or os.environ.get("DISPLAY") == ":99"
+        in_docker = _is_docker_runtime()
         display_width = _env_int("DISPLAY_WIDTH", Config.VIEWPORT_WIDTH)
         display_height = _env_int("DISPLAY_HEIGHT", Config.VIEWPORT_HEIGHT)
 
@@ -235,7 +243,6 @@ class BrowserManager:
             width = Config.VIEWPORT_WIDTH + random.randint(-20, 20)
             height = Config.VIEWPORT_HEIGHT + random.randint(-20, 20)
 
-        # Try real Chrome first, fall back to bundled Chromium
         chrome_args = [
             "--disable-blink-features=AutomationControlled",
             "--no-first-run",
@@ -246,6 +253,10 @@ class BrowserManager:
             # via --host-resolver-rules (see _resolve_domains_for_chrome).
             "--disable-features=AsyncDns,DnsOverHttps",
             "--dns-prefetch-disable",
+            # Local system extensions/ad blockers can break OpenAI auth flows
+            # even with a fresh user-data-dir.
+            "--disable-extensions",
+            "--disable-component-extensions-with-background-pages",
         ]
 
         # Docker-specific flags
@@ -278,13 +289,22 @@ class BrowserManager:
         else:
             launch_kwargs["viewport"] = {"width": width, "height": height}
 
+        browser_channel = Config.BROWSER_CHANNEL
         try:
-            self._context = await self._playwright.chromium.launch_persistent_context(
-                channel="chrome", **launch_kwargs
-            )
-            log.info("Launched with real Chrome")
+            if browser_channel in {"", "chromium", "bundled"}:
+                self._context = await self._playwright.chromium.launch_persistent_context(
+                    **launch_kwargs
+                )
+                log.info("Launched with bundled Chromium")
+            else:
+                self._context = await self._playwright.chromium.launch_persistent_context(
+                    channel=browser_channel, **launch_kwargs
+                )
+                log.info("Launched with browser channel: %s", browser_channel)
         except Exception:
-            log.info("Real Chrome not found, using bundled Chromium")
+            if browser_channel in {"", "chromium", "bundled"}:
+                raise
+            log.info("Browser channel %r not available, using bundled Chromium", browser_channel)
             self._context = await self._playwright.chromium.launch_persistent_context(
                 **launch_kwargs
             )

--- a/src/chatgpt/client.py
+++ b/src/chatgpt/client.py
@@ -50,6 +50,7 @@ class ChatGPTClient:
         self._page = page
         self._last_model_label = ""
         self._last_model_version_label = ""
+        self._last_model_setting_by_key: dict[str, str] = {}
         self._unavailable_model_keys: set[str] = set()
         self._recent_backend_events: list[dict] = []
         self._wire_backend_event_logger()
@@ -307,6 +308,7 @@ class ChatGPTClient:
             log.debug(f"No explicit browser model switch needed for request model={requested_model!r}")
             return
         target_version_label = self._model_version_label_for_option(target)
+        target_setting_label = self._model_setting_label_for_option(target)
         unavailable_keys = {
             key
             for key in (
@@ -326,7 +328,10 @@ class ChatGPTClient:
 
         current_label = await self._detect_current_model_label()
         if current_label and self._label_matches_model_option(current_label, target):
-            if not self._model_version_needs_configure(target, target_version_label):
+            if (
+                not self._model_version_needs_configure(target, target_version_label)
+                and self._model_setting_is_current(target, target_setting_label)
+            ):
                 self._last_model_label = target.ui_label
                 log.debug(f"ChatGPT model already selected: {target.ui_label}")
                 return
@@ -386,6 +391,18 @@ class ChatGPTClient:
                 return
             self._last_model_version_label = target_version_label
 
+        if target_setting_label and not self._model_setting_is_current(target, target_setting_label):
+            setting_configured = await self._ensure_model_setting(target, target_setting_label)
+            if not setting_configured:
+                visible_options = await self._collect_visible_model_options()
+                detail = f"Could not configure ChatGPT model setting '{target.ui_label} -> {target_setting_label}'"
+                if visible_options:
+                    detail = f"{detail}; visible options included: {', '.join(visible_options[:12])}"
+                await self._dismiss_model_picker()
+                self._handle_model_switch_failure(detail)
+                return
+            self._last_model_setting_by_key[self._model_setting_cache_key(target)] = target_setting_label
+
         if self._is_configure_only_version_option(target, target_version_label):
             confirmed = self._model_version_is_current(target_version_label)
             if not confirmed:
@@ -394,14 +411,19 @@ class ChatGPTClient:
                 )
                 return
         else:
-            confirmed = await self._wait_for_model_label(target.ui_labels)
+            confirmation_labels = self._model_confirmation_labels(target, target_setting_label)
+            confirmed = await self._wait_for_model_label(confirmation_labels)
             if not confirmed:
                 current_after = await self._detect_current_model_label()
-                if not self._label_matches_model_option(current_after, target):
+                if normalize_model_token(current_after) not in {
+                    normalize_model_token(label) for label in confirmation_labels
+                }:
                     await self._dismiss_model_picker()
                     await asyncio.sleep(1.0)
                     current_after = await self._detect_current_model_label()
-                    if not self._label_matches_model_option(current_after, target):
+                    if normalize_model_token(current_after) not in {
+                        normalize_model_token(label) for label in confirmation_labels
+                    }:
                         self._handle_model_switch_failure(
                             f"Model switch to '{target.ui_label}' could not be confirmed"
                         )
@@ -411,6 +433,8 @@ class ChatGPTClient:
         self._last_model_label = target.ui_label
         if target_version_label:
             self._last_model_version_label = target_version_label
+        if target_setting_label:
+            self._last_model_setting_by_key[self._model_setting_cache_key(target)] = target_setting_label
         log.info(f"Model switched to {target.ui_label}")
 
     # ── Navigation ──────────────────────────────────────────────
@@ -907,7 +931,11 @@ class ChatGPTClient:
 
     async def _detect_current_model_label(self) -> str:
         """Best-effort detection of the currently selected ChatGPT model label."""
-        known_labels = [label for option in list_switchable_models() for label in option.ui_labels]
+        known_labels = [
+            label
+            for option in list_switchable_models()
+            for label in self._model_confirmation_labels(option, self._model_setting_label_for_option(option))
+        ]
         if self._last_model_label and self._last_model_label not in known_labels:
             known_labels.append(self._last_model_label)
         if not known_labels:
@@ -1003,6 +1031,37 @@ class ChatGPTClient:
         target = normalize_model_token(target_version_label)
         current = normalize_model_token(self._last_model_version_label)
         return bool(target and current and target == current)
+
+    def _model_setting_label_for_option(self, option) -> str:
+        """Return the configured Standard/Extended picker setting for a model option."""
+        return (getattr(option, "setting_label", "") or "").strip()
+
+    def _model_setting_cache_key(self, option) -> str:
+        """Return the stable key used to remember a model's selected picker setting."""
+        return normalize_model_token(getattr(option, "public_id", "") or getattr(option, "ui_label", ""))
+
+    def _model_setting_is_current(self, option, target_setting_label: str) -> bool:
+        """Return whether the requested model setting was already selected."""
+        target = normalize_model_token(target_setting_label)
+        if not target:
+            return True
+        current = normalize_model_token(self._last_model_setting_by_key.get(self._model_setting_cache_key(option), ""))
+        return bool(current and current == target)
+
+    def _model_confirmation_labels(self, option, target_setting_label: str = "") -> tuple[str, ...]:
+        """Return visible labels that can confirm a successful model switch."""
+        labels = list(getattr(option, "ui_labels", ()) or ())
+        if target_setting_label:
+            labels.insert(0, target_setting_label)
+        seen: set[str] = set()
+        result: list[str] = []
+        for label in labels:
+            normalized = normalize_model_token(label)
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            result.append(label)
+        return tuple(result)
 
     def _model_version_needs_configure(self, option, target_version_label: str) -> bool:
         """
@@ -1162,6 +1221,8 @@ class ChatGPTClient:
             "Instant",
             "Thinking",
             "Latest",
+            "Standard",
+            "Extended",
             "Configure",
             "model",
             "GPT",
@@ -1363,6 +1424,153 @@ class ChatGPTClient:
             if await self._click_menu_text(target_label):
                 return True
         return False
+
+    async def _ensure_model_setting(self, option, setting_label: str) -> bool:
+        """Open a model row's settings submenu and select Standard/Extended."""
+        await self._dismiss_model_picker()
+        current_label = await self._detect_current_model_label()
+        opened = await self._open_model_picker(option.ui_label, current_label=current_label)
+        if not opened:
+            return False
+
+        await asyncio.sleep(0.3)
+        settings_opened = await self._click_model_setting_control(option.ui_labels)
+        if not settings_opened:
+            return False
+
+        await asyncio.sleep(0.3)
+        return await self._click_model_option((setting_label,))
+
+    async def _click_model_setting_control(self, target_labels: tuple[str, ...]) -> bool:
+        """Click the settings control beside a Thinking/Pro model row."""
+        labels = [label for label in target_labels if (label or "").strip()]
+        if not labels:
+            return False
+
+        row = await self._page.evaluate(
+            r"""
+            (targetLabels) => {
+                const normalize = (value) =>
+                    (value || "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+                const wanted = (targetLabels || []).map(normalize).filter(Boolean);
+                if (!wanted.length) return null;
+                const isVisible = (el) => {
+                    if (!el) return false;
+                    const rect = el.getBoundingClientRect();
+                    const style = window.getComputedStyle(el);
+                    return rect.width > 0 &&
+                        rect.height > 0 &&
+                        style.visibility !== "hidden" &&
+                        style.display !== "none";
+                };
+                const textFor = (el) => [
+                    el.innerText || "",
+                    el.textContent || "",
+                    el.getAttribute("aria-label") || "",
+                    el.getAttribute("title") || "",
+                ].join(" ");
+                const selectors = [
+                    "[role='menuitemradio']",
+                    "[role='menuitem']",
+                    "[data-testid^='model-switcher']",
+                    "[data-radix-collection-item]",
+                ];
+                const rows = [];
+                for (const selector of selectors) {
+                    for (const el of document.querySelectorAll(selector)) {
+                        if (!isVisible(el)) continue;
+                        const normalizedText = normalize(textFor(el));
+                        if (!normalizedText || !wanted.some((label) => normalizedText.includes(label))) continue;
+                        const rect = el.getBoundingClientRect();
+                        if (rect.width < 40 || rect.height < 20 || rect.top > window.innerHeight - 24) continue;
+                        rows.push({ el, rect });
+                    }
+                }
+                rows.sort((a, b) => a.rect.top - b.rect.top || a.rect.left - b.rect.left);
+                if (rows[0]) {
+                    const rect = rows[0].rect;
+                    return {
+                        left: rect.left,
+                        top: rect.top,
+                        width: rect.width,
+                        height: rect.height,
+                        x: Math.max(rect.left + rect.width - 18, rect.left + rect.width * 0.75),
+                        y: rect.top + rect.height / 2,
+                    };
+                }
+                return null;
+            }
+            """,
+            labels,
+        )
+        if not isinstance(row, dict) or "x" not in row or "y" not in row:
+            return False
+
+        await self._page.mouse.move(float(row["x"]), float(row["y"]), steps=8)
+        await asyncio.sleep(0.25)
+
+        candidate = await self._page.evaluate(
+            r"""
+            (row) => {
+                const normalize = (value) =>
+                    (value || "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+                const isVisible = (el) => {
+                    if (!el) return false;
+                    const rect = el.getBoundingClientRect();
+                    const style = window.getComputedStyle(el);
+                    return rect.width > 0 &&
+                        rect.height > 0 &&
+                        style.visibility !== "hidden" &&
+                        style.display !== "none";
+                };
+                const textFor = (el) => [
+                    el.innerText || "",
+                    el.textContent || "",
+                    el.getAttribute("aria-label") || "",
+                    el.getAttribute("title") || "",
+                    el.getAttribute("data-testid") || "",
+                ].join(" ");
+                const rowRight = row.left + row.width;
+                const rowBottom = row.top + row.height;
+                const controls = Array.from(document.querySelectorAll("button,[role='button'],[aria-label],[title],[data-testid]"))
+                    .filter((el) => {
+                        if (!isVisible(el)) return false;
+                        const rect = el.getBoundingClientRect();
+                        const centerY = rect.top + rect.height / 2;
+                        return centerY >= row.top - 6 &&
+                            centerY <= rowBottom + 6 &&
+                            rect.left >= row.left + row.width * 0.45 &&
+                            rect.left <= rowRight + 48;
+                    });
+                const scored = [];
+                for (const control of controls) {
+                    const rect = control.getBoundingClientRect();
+                    const text = normalize(textFor(control));
+                    let score = 0;
+                    if (/settings|setting|customize|preferences|options|sliders|model/.test(text)) score += 80;
+                    if (rect.width <= 48 && rect.height <= 48) score += 25;
+                    if (rect.left >= row.left + row.width * 0.6) score += 25;
+                    if (score) {
+                        scored.push({
+                            score,
+                            x: rect.left + rect.width / 2,
+                            y: rect.top + rect.height / 2,
+                        });
+                    }
+                }
+                scored.sort((a, b) => b.score - a.score);
+                return scored[0] || null;
+            }
+            """,
+            row,
+        )
+        if not isinstance(candidate, dict) or "x" not in candidate or "y" not in candidate:
+            return False
+
+        await self._page.mouse.move(float(candidate["x"]), float(candidate["y"]), steps=4)
+        await asyncio.sleep(0.05)
+        await self._page.mouse.click(float(candidate["x"]), float(candidate["y"]))
+        return True
 
     async def _select_model_from_configure_dialog(
         self,
@@ -1666,7 +1874,8 @@ class ChatGPTClient:
     def _label_matches_model_option(self, label: str, option) -> bool:
         """Return whether a visible UI label matches a configured model option."""
         normalized = normalize_model_token(label)
-        return bool(normalized and normalized in {normalize_model_token(item) for item in option.ui_labels})
+        labels = self._model_confirmation_labels(option, self._model_setting_label_for_option(option))
+        return bool(normalized and normalized in {normalize_model_token(item) for item in labels})
 
     async def _upload_files(self, file_paths: list[str]) -> None:
         """

--- a/src/chatgpt/model_registry.py
+++ b/src/chatgpt/model_registry.py
@@ -28,6 +28,7 @@ class BrowserModelOption:
     public_id: str
     ui_label: str
     alternate_labels: tuple[str, ...] = ()
+    setting_label: str = ""
 
     @property
     def ui_labels(self) -> tuple[str, ...]:
@@ -75,9 +76,52 @@ def _parse_model_aliases(raw: str) -> list[BrowserModelOption]:
     return options
 
 
+def _parse_model_settings(raw: str) -> dict[str, str]:
+    """Parse model setting mappings like `gpt-5.5-thinking=Extended,Pro=Standard`."""
+    settings: dict[str, str] = {}
+    for chunk in (raw or "").split(","):
+        item = chunk.strip()
+        if not item or "=" not in item:
+            continue
+        model_key, setting_label = item.split("=", 1)
+        normalized = normalize_model_token(model_key)
+        setting_label = setting_label.strip()
+        if normalized and setting_label:
+            settings[normalized] = setting_label
+    return settings
+
+
+def _apply_model_settings(options: list[BrowserModelOption], raw_settings: str) -> list[BrowserModelOption]:
+    """Attach optional picker setting labels to configured model options."""
+    settings = _parse_model_settings(raw_settings)
+    if not settings:
+        return options
+
+    configured: list[BrowserModelOption] = []
+    for option in options:
+        lookup_keys = [
+            normalize_model_token(option.public_id),
+            *(normalize_model_token(label) for label in option.ui_labels),
+        ]
+        setting_label = next((settings[key] for key in lookup_keys if key in settings), "")
+        if not setting_label:
+            configured.append(option)
+            continue
+        configured.append(
+            BrowserModelOption(
+                public_id=option.public_id,
+                ui_label=option.ui_label,
+                alternate_labels=option.alternate_labels,
+                setting_label=setting_label,
+            )
+        )
+    return configured
+
+
 def list_switchable_models() -> list[BrowserModelOption]:
     """Return the configured explicit browser-switchable models."""
-    return _parse_model_aliases(Config.CHATGPT_MODEL_ALIASES)
+    options = _parse_model_aliases(Config.CHATGPT_MODEL_ALIASES)
+    return _apply_model_settings(options, Config.CHATGPT_MODEL_SETTINGS)
 
 
 def list_public_chat_models() -> list[str]:

--- a/src/config.py
+++ b/src/config.py
@@ -44,12 +44,17 @@ class Config:
     # Browser
     HEADLESS: bool = os.getenv("HEADLESS", "false").lower() == "true"
     SLOW_MO: int = int(os.getenv("SLOW_MO", "25"))
+    BROWSER_CHANNEL: str = os.getenv("BROWSER_CHANNEL", "chrome").strip().lower()
     CHATGPT_URL: str = os.getenv("CHATGPT_URL", "https://chatgpt.com")
     CLAUDE_URL: str = os.getenv("CLAUDE_URL", "https://claude.ai")
     CHATGPT_DEFAULT_MODEL: str = os.getenv("CHATGPT_DEFAULT_MODEL", "")
     CHATGPT_MODEL_ALIASES: str = os.getenv(
         "CHATGPT_MODEL_ALIASES",
-        "gpt-5.5=Instant|Latest 5.5|5.5|GPT-5.5,gpt-5.5-thinking=Thinking|5.5 Thinking|GPT-5.5 Thinking,gpt-5.4=5.4|GPT-5.4,gpt-5.3=5.3|GPT-5.3,gpt-5.2=5.2|GPT-5.2,gpt-5.1=5.1|GPT-5.1,gpt-5=GPT-5,gpt-5-mini=GPT-5 mini,gpt-5-nano=GPT-5 nano,o3=o3,o4-mini=o4-mini,gpt-4.5=GPT-4.5,gpt-4.1=GPT-4.1,gpt-4.1-mini=GPT-4.1 mini,gpt-4o=GPT-4o",
+        "gpt-5.5=Instant|Latest 5.5|5.5|GPT-5.5,gpt-5.5-thinking=Thinking|5.5 Thinking|GPT-5.5 Thinking,gpt-5.5-pro=Pro|5.5 Pro|GPT-5.5 Pro,gpt-5.4=5.4|GPT-5.4,gpt-5.3=5.3|GPT-5.3,gpt-5.2=5.2|GPT-5.2,gpt-5.1=5.1|GPT-5.1,gpt-5=GPT-5,gpt-5-mini=GPT-5 mini,gpt-5-nano=GPT-5 nano,o3=o3,o4-mini=o4-mini,gpt-4.5=GPT-4.5,gpt-4.1=GPT-4.1,gpt-4.1-mini=GPT-4.1 mini,gpt-4o=GPT-4o",
+    )
+    CHATGPT_MODEL_SETTINGS: str = os.getenv(
+        "CHATGPT_MODEL_SETTINGS",
+        "gpt-5.5-thinking=Standard,gpt-5.5-pro=Standard",
     )
     CHATGPT_MODEL_SWITCH_TIMEOUT: int = int(os.getenv("CHATGPT_MODEL_SWITCH_TIMEOUT", "10000"))
     CHATGPT_MODEL_SWITCH_STRICT: bool = os.getenv("CHATGPT_MODEL_SWITCH_STRICT", "false").lower() == "true"

--- a/tests/test_chatgpt_client_model_switch.py
+++ b/tests/test_chatgpt_client_model_switch.py
@@ -134,6 +134,35 @@ class _ConfigureOnlyClient(ChatGPTClient):
         return None
 
 
+class _SettingClient(ChatGPTClient):
+    def __init__(self, page) -> None:
+        super().__init__(page)
+        self.setting_calls: list[tuple[str, str]] = []
+
+    async def _detect_current_model_label(self) -> str:
+        return "Instant"
+
+    async def _open_model_picker(self, _target_label: str, current_label: str = "") -> bool:
+        return True
+
+    async def _click_model_option(self, _target_labels: tuple[str, ...]) -> bool:
+        return True
+
+    async def _ensure_model_setting(self, option, setting_label: str) -> bool:
+        self.setting_calls.append((option.public_id, setting_label))
+        return True
+
+    async def _ensure_configured_model_version(self, target_version_label: str) -> bool:
+        self._last_model_version_label = target_version_label
+        return True
+
+    async def _wait_for_model_label(self, _target_labels: tuple[str, ...]) -> bool:
+        return True
+
+    async def _dismiss_model_picker(self) -> None:
+        return None
+
+
 class ChatGPTClientModelSwitchTests(unittest.IsolatedAsyncioTestCase):
     async def test_missing_model_option_falls_back_and_caches_when_not_strict(self) -> None:
         page = _FakePage(open_picker=True, visible_options=["GPT-5", "o3"])
@@ -187,6 +216,28 @@ class ChatGPTClientModelSwitchTests(unittest.IsolatedAsyncioTestCase):
         labels = client._configure_version_click_labels(("Instant", "Latest 5.5", "GPT-5.5"), "5.5")
 
         self.assertEqual(labels[:3], ("5.5", "Instant", "Latest 5.5"))
+
+    async def test_model_setting_is_applied_for_configured_thinking_mode(self) -> None:
+        page = _FakePage(open_picker=True)
+        client = _SettingClient(page)  # type: ignore[arg-type]
+
+        with patch.object(
+            Config,
+            "CHATGPT_MODEL_ALIASES",
+            "gpt-5.5-thinking=Thinking|5.5 Thinking",
+        ), patch.object(
+            Config,
+            "CHATGPT_MODEL_SETTINGS",
+            "gpt-5.5-thinking=Extended",
+        ), patch.object(
+            Config,
+            "CHATGPT_MODEL_SWITCH_STRICT",
+            True,
+        ), patch("src.chatgpt.client.asyncio.sleep", _noop_sleep):
+            await client.ensure_model("gpt-5.5-thinking")
+
+        self.assertEqual(client.setting_calls, [("gpt-5.5-thinking", "Extended")])
+        self.assertEqual(client._last_model_setting_by_key["gpt55thinking"], "Extended")
 
     async def test_model_picker_fallback_clicks_version_labeled_composer_button(self) -> None:
         if async_playwright is None:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -17,9 +17,11 @@ class ModelRegistryTests(unittest.TestCase):
     def test_default_models_include_pro_composer_latest_alias(self) -> None:
         self.assertIn("gpt-5.5", model_registry.list_public_chat_models())
         self.assertIn("gpt-5.5-thinking", model_registry.list_public_chat_models())
+        self.assertIn("gpt-5.5-pro", model_registry.list_public_chat_models())
         self.assertIn("gpt-5.1", model_registry.list_public_chat_models())
         self.assertTrue(model_registry.is_supported_chat_model("Instant"))
         self.assertTrue(model_registry.is_supported_chat_model("Thinking"))
+        self.assertTrue(model_registry.is_supported_chat_model("Pro"))
         self.assertTrue(model_registry.is_supported_chat_model("Latest 5.5"))
         self.assertTrue(model_registry.is_supported_chat_model("5.5"))
         self.assertTrue(model_registry.is_supported_chat_model("GPT-5.5"))
@@ -31,6 +33,26 @@ class ModelRegistryTests(unittest.TestCase):
             assert resolved is not None
             self.assertEqual(resolved.ui_label, "Instant")
             self.assertEqual(resolved.alternate_labels, ("Latest 5.5", "5.5", "GPT-5.5"))
+
+    def test_model_settings_attach_to_public_id_or_ui_label(self) -> None:
+        with patch.object(
+            model_registry.Config,
+            "CHATGPT_MODEL_ALIASES",
+            "gpt-5.5-thinking=Thinking|5.5 Thinking,gpt-5.5-pro=Pro",
+        ), patch.object(
+            model_registry.Config,
+            "CHATGPT_MODEL_SETTINGS",
+            "gpt-5.5-thinking=Extended,Pro=Standard",
+        ):
+            thinking = model_registry.resolve_requested_model("gpt-5.5-thinking")
+            pro = model_registry.resolve_requested_model("gpt-5.5-pro")
+
+        self.assertIsNotNone(thinking)
+        self.assertIsNotNone(pro)
+        assert thinking is not None
+        assert pro is not None
+        self.assertEqual(thinking.setting_label, "Extended")
+        self.assertEqual(pro.setting_label, "Standard")
 
     def test_supported_model_accepts_public_id_and_ui_label(self) -> None:
         with patch.object(model_registry.Config, "CHATGPT_MODEL_ALIASES", "gpt-4.1-mini=GPT-4.1 mini"):


### PR DESCRIPTION
This pull request introduces support for configuring and auto-selecting additional ChatGPT model picker settings (such as "Standard" and "Extended") for models like `gpt-5.5-thinking` and `gpt-5.5-pro`. It also improves browser launch flexibility and Docker detection, and updates documentation accordingly. The changes enhance the ability to control model and picker row selection via environment variables and improve robustness in browser management.