### PR TITLE
Add Long-Prompt Attachment Fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ MINIMAX_MODEL=MiniMax-M2.7
 # currently selected ChatGPT UI model.
 CHATGPT_DEFAULT_MODEL=
 CHATGPT_MODEL_SWITCH_TIMEOUT=10000
+CHATGPT_LONG_PROMPT_FALLBACK=attachment
+# 0 lets the ChatGPT UI determine when the composer limit is reached.
+CHATGPT_LONG_PROMPT_THRESHOLD=0
 
 # Timeouts (milliseconds)
 RESPONSE_TIMEOUT=120000

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ environment:
 | `CHATGPT_MODEL_SETTINGS` | Instant/Medium/High/Extra High/Pro mappings | Comma-separated effort map used through Advanced → Effort. |
 | `CHATGPT_MODEL_SWITCH_TIMEOUT` | `10000` | Milliseconds to wait for a model label after switching. |
 | `CHATGPT_MODEL_SWITCH_STRICT` | `false` | Return an error when a configured model is not visible instead of continuing. |
+| `CHATGPT_LONG_PROMPT_FALLBACK` | `attachment` | Handle a ChatGPT composer length rejection by uploading the full prompt as a UTF-8 `.txt` attachment; use `error` to return HTTP 413 instead. |
+| `CHATGPT_LONG_PROMPT_THRESHOLD` | `0` | Optional proactive character threshold. `0` uses ChatGPT's live UI validation instead of a hard-coded limit. |
 
 ### API
 

--- a/src/api/openai_routes.py
+++ b/src/api/openai_routes.py
@@ -63,6 +63,7 @@ from src.api.browser_gate import (
     browser_access_lock,
 )
 from src.chatgpt.client import ChatGPTClient
+from src.chatgpt.errors import PromptAttachmentFallbackError, PromptTooLongError
 from src.claude.client import ClaudeClient
 from src.minimax.client import MiniMaxClient
 from src.chatgpt.model_registry import (
@@ -2533,6 +2534,12 @@ async def _execute_chat_completion(
                 else:
                     send_kwargs["stateless"] = True
                 result = await client.send_message(prompt, **send_kwargs)
+            except PromptTooLongError as e:
+                log.warning("ChatGPT rejected an oversized prompt: %s", e)
+                raise HTTPException(status_code=413, detail=str(e)) from e
+            except PromptAttachmentFallbackError as e:
+                log.error("Long-prompt attachment fallback failed: %s", e, exc_info=True)
+                raise HTTPException(status_code=502, detail=str(e)) from e
             except Exception as e:
                 log.error(f"ChatGPT error: {e}", exc_info=True)
                 raise HTTPException(status_code=500, detail=f"ChatGPT error: {str(e)}")
@@ -2744,6 +2751,7 @@ async def _run_async_chat_job(job_id: str, request: ChatCompletionRequest, app_k
             if job is not None:
                 job.status = "failed"
                 job.error = str(e)
+                job.error_status_code = int(getattr(e, "status_code", 500))
 
 
 async def _submit_async_chat_job(

--- a/src/api/openai_schemas.py
+++ b/src/api/openai_schemas.py
@@ -152,6 +152,7 @@ class ChatCompletionJobResponse(BaseModel):
     model: str = "catgpt-browser"
     response: Optional[ChatCompletionResponse] = None
     error: Optional[str] = None
+    error_status_code: Optional[int] = None
 
 
 # ── Models endpoint ─────────────────────────────────────────────

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -25,6 +25,7 @@ from src.api.schemas import (
 )
 from src.browser.manager import BrowserManager
 from src.chatgpt.client import ChatGPTClient
+from src.chatgpt.errors import PromptAttachmentFallbackError, PromptTooLongError
 from src.chatgpt.model_registry import is_supported_chat_model, list_public_chat_models
 from src.claude.client import ClaudeClient
 from src.minimax.client import MiniMaxClient
@@ -131,6 +132,12 @@ async def chat(req: ChatRequest) -> ChatResponse:
                 read_aloud=req.read_aloud,
             )
             return _build_response(result)
+        except PromptTooLongError as e:
+            log.warning("ChatGPT rejected an oversized prompt: %s", e)
+            raise HTTPException(status_code=413, detail=str(e)) from e
+        except PromptAttachmentFallbackError as e:
+            log.error("Long-prompt attachment fallback failed: %s", e, exc_info=True)
+            raise HTTPException(status_code=502, detail=str(e)) from e
         except Exception as e:
             log.error(f"Chat error: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
@@ -155,6 +162,12 @@ async def chat_in_thread(thread_id: str, req: ChatRequest) -> ChatResponse:
                 read_aloud=req.read_aloud,
             )
             return _build_response(result)
+        except PromptTooLongError as e:
+            log.warning("ChatGPT rejected an oversized prompt: %s", e)
+            raise HTTPException(status_code=413, detail=str(e)) from e
+        except PromptAttachmentFallbackError as e:
+            log.error("Long-prompt attachment fallback failed: %s", e, exc_info=True)
+            raise HTTPException(status_code=502, detail=str(e)) from e
         except Exception as e:
             log.error(f"Thread chat error: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
@@ -176,6 +189,12 @@ async def new_thread(req: ChatRequest) -> ChatResponse:
                 read_aloud=req.read_aloud,
             )
             return _build_response(result)
+        except PromptTooLongError as e:
+            log.warning("ChatGPT rejected an oversized prompt: %s", e)
+            raise HTTPException(status_code=413, detail=str(e)) from e
+        except PromptAttachmentFallbackError as e:
+            log.error("Long-prompt attachment fallback failed: %s", e, exc_info=True)
+            raise HTTPException(status_code=502, detail=str(e)) from e
         except Exception as e:
             log.error(f"New thread error: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))

--- a/src/chatgpt/client.py
+++ b/src/chatgpt/client.py
@@ -9,8 +9,12 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import os
 import re
+import tempfile
 import time
+from pathlib import Path
+from typing import Literal
 
 from patchright.async_api import Page
 
@@ -35,9 +39,13 @@ from src.chatgpt.detector import (
 from src.chatgpt.image_handler import extract_images_from_response
 from src.chatgpt.audio_handler import generate_read_aloud_audio
 from src.chatgpt.models import ChatResponse
+from src.chatgpt.errors import PromptAttachmentFallbackError, PromptTooLongError
 from src.log import setup_logging
 
 log = setup_logging("chatgpt_client")
+
+SendButtonState = Literal["clicked", "disabled", "missing"]
+PromptSubmissionState = Literal["ready", "prompt-too-long", "disabled", "unknown"]
 
 
 class ChatGPTClient:
@@ -99,6 +107,7 @@ class ChatGPTClient:
         Returns ChatResponse with the assistant's reply and metadata.
         """
         all_attachments = (image_paths or []) + (file_paths or [])
+        temporary_prompt_path: str | None = None
         log.info(f"Sending message ({len(text)} chars, {len(all_attachments)} attachments): {text[:80]}...")
         start_time = time.time()
 
@@ -134,157 +143,191 @@ class ChatGPTClient:
         if not input_selector:
             raise RuntimeError("Could not find chat input element")
 
-        # 3. Paste the message first so composer clear/delete cannot wipe attachments.
-        await human_type(self._page, input_selector, text)
+        submitted_text = text
+        try:
+            # 3. Paste the message first so composer clear/delete cannot wipe attachments.
+            await human_type(self._page, input_selector, text)
 
-        # 3.5. Attach files after text is in the composer.
-        if all_attachments:
-            await self._upload_files(all_attachments)
-
-        # Small pause after pasting (like a human reviewing before send)
-        await random_delay(300, 600)
-
-        auto_submitted = False
-        sent = False
-        if auto_submitted:
-            log.info("ChatGPT auto-submitted after text entry — skipping send button click")
-        else:
-            # No auto-submit — click the send button
-            log.info("No auto-submit detected, clicking send button")
-            sent = await self._click_send()
-            if not sent:
-                log.info("Send button not found, trying Enter key")
-                await self._page.keyboard.press("Enter")
-
-        submitted = await self._wait_for_message_submission(pre_user_signature, text)
-        if not submitted:
-            diagnostic_path = await capture_response_diagnostics(
-                self._page,
-                "message-not-submitted",
-                previous_turn_signature=pre_turn_signature,
-                extra={
-                    "recent_backend_events": self._backend_events_snapshot(),
-                    "prompt_length": len(text),
-                    "sent_by_button": sent,
-                },
-            )
-            detail = "Message was not submitted to ChatGPT"
-            if diagnostic_path:
-                detail = f"{detail}; diagnostic={diagnostic_path}"
-            raise RuntimeError(detail)
-
-        # 5. Wait for response with message count awareness
-        log.info("Waiting for ChatGPT response...")
-        expected_count = pre_count + 1
-        completed = await wait_for_response_complete(
-            self._page,
-            expected_msg_count=expected_count,
-            previous_turn_signature=pre_turn_signature,
-        )
-
-        if not completed:
-            log.warning("Response may not be complete (timeout)")
-            await capture_response_diagnostics(
-                self._page,
-                "response-timeout",
-                previous_turn_signature=pre_turn_signature,
-                extra={
-                    "recent_backend_events": self._backend_events_snapshot(),
-                    "prompt_length": len(text),
-                    "expected_assistant_count": expected_count,
-                },
-            )
-
-        # Small buffer after completion to let DOM settle
-        await asyncio.sleep(1.0)
-
-        # 6. Check for generated images in the response FIRST
-        #    (image turns have no copy button, so we must detect images
-        #    before trying copy-button extraction)
-        images = await extract_images_from_response(
-            self._page,
-            previous_turn_signature=pre_turn_signature,
-        )
-        has_images = len(images) > 0
-
-        # 7. Extract text content
-        if has_images:
-            # Image responses don't have a copy button — extract text
-            # from the turn's DOM instead (will get the image title/desc)
-            response_text = await self._extract_image_turn_text(pre_turn_signature)
-            log.info(f"Response contains {len(images)} generated image(s)")
-            for img in images:
-                log.info(f"  Image: {img.alt or img.prompt_title} → {img.local_path}")
-        else:
-            # Standard text response — use copy button (most reliable)
-            response_text = await extract_last_response_via_copy(
-                self._page,
-                previous_turn_signature=pre_turn_signature,
-            )
-
-            # ChatGPT can briefly expose status text like "thinking" as a turn.
-            # Retry against the same new turn before giving that transient text back.
-            if is_incomplete_response_text(response_text):
-                log.warning("Extracted text looks incomplete/transient; retrying for final answer")
-                for attempt in range(1, 3):
-                    await asyncio.sleep(2)
-                    await wait_for_response_complete(
-                        self._page,
-                        timeout_ms=90000,
-                        previous_turn_signature=pre_turn_signature,
-                    )
-                    retry_text = await extract_last_response_via_copy(
-                        self._page,
-                        previous_turn_signature=pre_turn_signature,
+            prompt_state = await self._prompt_submission_state(text)
+            if prompt_state == "prompt-too-long":
+                if Config.CHATGPT_LONG_PROMPT_FALLBACK != "attachment":
+                    raise PromptTooLongError(
+                        "ChatGPT rejected the prompt as too long and the attachment fallback is disabled"
                     )
 
-                    if retry_text and not is_incomplete_response_text(retry_text):
-                        response_text = retry_text
-                        log.info(f"Recovered final response text on retry {attempt}")
-                        break
+                temporary_prompt_path = self._create_prompt_attachment(text)
+                attachment_name = Path(temporary_prompt_path).name
+                submitted_text = (
+                    f"Read the attached file `{attachment_name}` as the complete user request. "
+                    "Follow its instructions exactly and use all of its content before answering."
+                )
+                log.info(
+                    "Prompt is too long for the ChatGPT composer; using attachment fallback (%s)",
+                    attachment_name,
+                )
+                await human_type(self._page, input_selector, submitted_text)
+                all_attachments = [*all_attachments, temporary_prompt_path]
 
-                    if retry_text:
-                        response_text = retry_text
-                    log.warning(f"Retry {attempt} still incomplete/transient")
+            # 3.5. Attach files after text is in the composer.
+            if all_attachments:
+                await self._upload_files(all_attachments)
 
-            if not response_text or is_incomplete_response_text(response_text):
-                await capture_response_diagnostics(
+            # Small pause after pasting (like a human reviewing before send)
+            await random_delay(300, 600)
+
+            auto_submitted = False
+            sent = False
+            if auto_submitted:
+                log.info("ChatGPT auto-submitted after text entry — skipping send button click")
+            else:
+                # No auto-submit — click the send button
+                log.info("No auto-submit detected, clicking send button")
+                send_state = await self._click_send()
+                sent = send_state == "clicked"
+                if send_state == "missing":
+                    log.info("Send button not found, trying Enter key")
+                    await self._page.keyboard.press("Enter")
+                elif send_state == "disabled":
+                    log.warning("Send button is disabled; refusing to submit with Enter")
+                    raise RuntimeError("ChatGPT send button is disabled; message was not submitted")
+
+            submitted = await self._wait_for_message_submission(pre_user_signature, submitted_text)
+            if not submitted:
+                diagnostic_path = await capture_response_diagnostics(
                     self._page,
-                    "empty-or-incomplete-response",
+                    "message-not-submitted",
                     previous_turn_signature=pre_turn_signature,
                     extra={
                         "recent_backend_events": self._backend_events_snapshot(),
                         "prompt_length": len(text),
-                        "has_images": has_images,
+                        "sent_by_button": sent,
+                        "prompt_submission_state": prompt_state,
                     },
                 )
+                detail = "Message was not submitted to ChatGPT"
+                if diagnostic_path:
+                    detail = f"{detail}; diagnostic={diagnostic_path}"
+                raise RuntimeError(detail)
 
-        elapsed_ms = int((time.time() - start_time) * 1000)
-        thread_id = self._extract_thread_id()
-        audio = None
-
-        if read_aloud and response_text:
-            audio = await generate_read_aloud_audio(
+            # 5. Wait for response with message count awareness
+            log.info("Waiting for ChatGPT response...")
+            expected_count = pre_count + 1
+            completed = await wait_for_response_complete(
                 self._page,
+                expected_msg_count=expected_count,
                 previous_turn_signature=pre_turn_signature,
             )
 
-        log.info(
-            f"Response received ({elapsed_ms}ms, {len(response_text)} chars"
-            f"{f', {len(images)} images' if has_images else ''}"
-            f"{', audio' if audio else ''}): "
-            f"{response_text[:80]}..."
-        )
+            if not completed:
+                log.warning("Response may not be complete (timeout)")
+                await capture_response_diagnostics(
+                    self._page,
+                    "response-timeout",
+                    previous_turn_signature=pre_turn_signature,
+                    extra={
+                        "recent_backend_events": self._backend_events_snapshot(),
+                        "prompt_length": len(text),
+                        "expected_assistant_count": expected_count,
+                    },
+                )
 
-        return ChatResponse(
-            message=response_text,
-            thread_id=thread_id,
-            response_time_ms=elapsed_ms,
-            images=images,
-            has_images=has_images,
-            audio=audio,
-            has_audio=audio is not None,
-        )
+            # Small buffer after completion to let DOM settle
+            await asyncio.sleep(1.0)
+
+            # 6. Check for generated images in the response FIRST
+            #    (image turns have no copy button, so we must detect images
+            #    before trying copy-button extraction)
+            images = await extract_images_from_response(
+                self._page,
+                previous_turn_signature=pre_turn_signature,
+            )
+            has_images = len(images) > 0
+
+            # 7. Extract text content
+            if has_images:
+                # Image responses don't have a copy button — extract text
+                # from the turn's DOM instead (will get the image title/desc)
+                response_text = await self._extract_image_turn_text(pre_turn_signature)
+                log.info(f"Response contains {len(images)} generated image(s)")
+                for img in images:
+                    log.info(f"  Image: {img.alt or img.prompt_title} → {img.local_path}")
+            else:
+                # Standard text response — use copy button (most reliable)
+                response_text = await extract_last_response_via_copy(
+                    self._page,
+                    previous_turn_signature=pre_turn_signature,
+                )
+
+                # ChatGPT can briefly expose status text like "thinking" as a turn.
+                # Retry against the same new turn before giving that transient text back.
+                if is_incomplete_response_text(response_text):
+                    log.warning("Extracted text looks incomplete/transient; retrying for final answer")
+                    for attempt in range(1, 3):
+                        await asyncio.sleep(2)
+                        await wait_for_response_complete(
+                            self._page,
+                            timeout_ms=90000,
+                            previous_turn_signature=pre_turn_signature,
+                        )
+                        retry_text = await extract_last_response_via_copy(
+                            self._page,
+                            previous_turn_signature=pre_turn_signature,
+                        )
+
+                        if retry_text and not is_incomplete_response_text(retry_text):
+                            response_text = retry_text
+                            log.info(f"Recovered final response text on retry {attempt}")
+                            break
+
+                        if retry_text:
+                            response_text = retry_text
+                        log.warning(f"Retry {attempt} still incomplete/transient")
+
+                if not response_text or is_incomplete_response_text(response_text):
+                    await capture_response_diagnostics(
+                        self._page,
+                        "empty-or-incomplete-response",
+                        previous_turn_signature=pre_turn_signature,
+                        extra={
+                            "recent_backend_events": self._backend_events_snapshot(),
+                            "prompt_length": len(text),
+                            "has_images": has_images,
+                        },
+                    )
+
+            elapsed_ms = int((time.time() - start_time) * 1000)
+            thread_id = self._extract_thread_id()
+            audio = None
+
+            if read_aloud and response_text:
+                audio = await generate_read_aloud_audio(
+                    self._page,
+                    previous_turn_signature=pre_turn_signature,
+                )
+
+            log.info(
+                f"Response received ({elapsed_ms}ms, {len(response_text)} chars"
+                f"{f', {len(images)} images' if has_images else ''}"
+                f"{', audio' if audio else ''}): "
+                f"{response_text[:80]}..."
+            )
+
+            return ChatResponse(
+                message=response_text,
+                thread_id=thread_id,
+                response_time_ms=elapsed_ms,
+                images=images,
+                has_images=has_images,
+                audio=audio,
+                has_audio=audio is not None,
+            )
+        finally:
+            if temporary_prompt_path:
+                try:
+                    Path(temporary_prompt_path).unlink(missing_ok=True)
+                    log.debug("Removed temporary long-prompt attachment: %s", temporary_prompt_path)
+                except OSError as exc:
+                    log.warning("Could not remove temporary long-prompt attachment %s: %s", temporary_prompt_path, exc)
 
     async def generate_image(
         self,
@@ -737,6 +780,55 @@ class ChatGPTClient:
         """Return the current browser/page error state, if one is visible."""
         return await _check_page_error(self._page)
 
+    async def _prompt_submission_state(self, text: str) -> PromptSubmissionState:
+        """Classify the composer before attachments and submission."""
+        if Config.CHATGPT_LONG_PROMPT_THRESHOLD and len(text) >= Config.CHATGPT_LONG_PROMPT_THRESHOLD:
+            return "prompt-too-long"
+
+        await asyncio.sleep(0.15)
+        state = await self._composer_state()
+        if not state:
+            return "unknown"
+        if state.get("promptTooLong"):
+            return "prompt-too-long"
+
+        send_button = state.get("sendButton")
+        if isinstance(send_button, dict) and (
+            send_button.get("disabled")
+            or str(send_button.get("ariaDisabled") or "").lower() == "true"
+        ):
+            # ChatGPT currently does not always render a validation message for
+            # oversized prompts. In the live UI it leaves the populated
+            # composer intact and sets aria-disabled="true" on Send. Treat that
+            # stable, non-generating state as the same prompt-too-long signal so
+            # the attachment fallback can run. An active response can also
+            # disable Send, so keep that case distinct.
+            if str(state.get("composerText") or "").strip() and not state.get("hasStopButton"):
+                return "prompt-too-long"
+            return "disabled"
+        return "ready"
+
+    @staticmethod
+    def _create_prompt_attachment(text: str) -> str:
+        """Persist a prompt as a UTF-8 temporary file for ChatGPT upload."""
+        file_descriptor, filename = tempfile.mkstemp(
+            prefix="catgpt-long-prompt-",
+            suffix=".txt",
+        )
+        try:
+            with os.fdopen(file_descriptor, "w", encoding="utf-8", newline="") as handle:
+                handle.write(text)
+        except Exception as exc:
+            try:
+                os.close(file_descriptor)
+            except OSError:
+                pass
+            Path(filename).unlink(missing_ok=True)
+            raise PromptAttachmentFallbackError(
+                f"Could not create the temporary prompt attachment: {exc}"
+            ) from exc
+        return filename
+
     async def _wait_for_message_submission(
         self,
         previous_user_signature: str | None,
@@ -781,7 +873,7 @@ class ChatGPTClient:
         return False
 
     async def _composer_state(self) -> dict:
-        """Read composer/stop-button state from the page."""
+        """Read composer, validation, and send-button state from the page."""
         try:
             state = await self._page.evaluate(
                 """
@@ -805,9 +897,46 @@ class ChatGPTClient:
                         'button[aria-label="Stop generating"]',
                         'button[aria-label*="stop" i]'
                     ].join(',');
+                    const sendSelectors = [
+                        'button[data-testid="send-button"]',
+                        '#composer-submit-button',
+                        "button[aria-label='Send prompt']",
+                    ];
+                    let sendButton = null;
+                    for (const selector of sendSelectors) {
+                        const candidate = document.querySelector(selector);
+                        if (candidate) {
+                            sendButton = {
+                                selector,
+                                disabled: Boolean(candidate.disabled),
+                                ariaDisabled: candidate.getAttribute('aria-disabled'),
+                                visible: isVisible(candidate),
+                            };
+                            break;
+                        }
+                    }
+                    const validationNodes = Array.from(document.querySelectorAll(
+                        '[role="alert"], [aria-live], [data-state="error"], [class*="error" i], [class*="alert" i]'
+                    ));
+                    const validationText = validationNodes
+                        .filter(isVisible)
+                        .map(textOf)
+                        .filter(Boolean)
+                        .join(' ')
+                        .slice(-2000);
+                    // The composer and its toast/validation area are normally
+                    // near the end of body text. Limiting this avoids treating
+                    // an old error in conversation history as current state.
+                    const visibleText = ((document.body && document.body.innerText) || '').slice(-4000);
+                    const promptTooLong = /(?:message|prompt|input).{0,50}too long|too long.{0,50}(?:message|prompt|input)|(?:exceed|exceeds|maximum).{0,50}(?:character|token|length|limit)|(?:character|token|length).{0,50}(?:limit|maximum)/i.test(
+                        `${validationText} ${visibleText}`
+                    );
                     return {
                         composerText: textOf(composer),
                         hasStopButton: Array.from(document.querySelectorAll(stopSelector)).some(isVisible),
+                        sendButton,
+                        validationText,
+                        promptTooLong,
                     };
                 }
                 """
@@ -904,8 +1033,8 @@ class ChatGPTClient:
         except Exception as e:
             log.debug(f"Overlay check failed: {e}")
 
-    async def _click_send(self) -> bool:
-        """Try to click the send button using selector fallbacks."""
+    async def _click_send(self) -> SendButtonState:
+        """Try to click Send, distinguishing disabled from missing controls."""
         # Check send button state before clicking
         btn_state = await self._page.evaluate(
             """
@@ -934,16 +1063,19 @@ class ChatGPTClient:
         log.debug(f"Send button state: {btn_state}")
 
         # Don't click a disabled send button — the input wasn't recognized
-        if isinstance(btn_state, dict) and btn_state.get("disabled"):
-            log.warning("Send button is disabled — text may not have been inserted properly")
-            return False
+        if isinstance(btn_state, dict) and (
+            btn_state.get("disabled")
+            or str(btn_state.get("ariaDisabled") or "").lower() == "true"
+        ):
+            log.warning("Send button is disabled — refusing to submit with Enter")
+            return "disabled"
 
         selector = await self._find_selector(Selectors.SEND_BUTTON, "send button")
         if selector:
             await human_click(self._page, selector)
             log.info(f"Send button clicked via: {selector}")
-            return True
-        return False
+            return "clicked"
+        return "missing"
 
     async def _detect_current_model_label(self) -> str:
         """Best-effort detection of the currently selected ChatGPT model label."""

--- a/src/chatgpt/errors.py
+++ b/src/chatgpt/errors.py
@@ -1,0 +1,15 @@
+"""Typed errors raised while submitting prompts through the ChatGPT UI."""
+
+from __future__ import annotations
+
+
+class PromptTooLongError(RuntimeError):
+    """The ChatGPT composer rejected a prompt because it is too large."""
+
+    status_code = 413
+
+
+class PromptAttachmentFallbackError(RuntimeError):
+    """The long-prompt attachment fallback could not be completed."""
+
+    status_code = 502

--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -53,7 +53,7 @@ log = setup_logging("cli", log_file="cli.log")
 cli = typer.Typer(no_args_is_help=False, add_completion=False)
 
 # ── Constants ────────────────────────────────────────────────────
-VERSION = "6.0.0"
+VERSION = "6.1.0"
 APP_NAME = "CATGPT"
 APP_TAGLINE = "OpenAI-Compatible Terminal Chat"
 

--- a/src/config.py
+++ b/src/config.py
@@ -75,6 +75,14 @@ class Config:
     )
     CHATGPT_MODEL_SWITCH_TIMEOUT: int = int(os.getenv("CHATGPT_MODEL_SWITCH_TIMEOUT", "10000"))
     CHATGPT_MODEL_SWITCH_STRICT: bool = os.getenv("CHATGPT_MODEL_SWITCH_STRICT", "false").lower() == "true"
+    # Browser UI-driven long-prompt fallback.  The threshold is optional because
+    # ChatGPT's effective composer limit can vary by model/account.
+    CHATGPT_LONG_PROMPT_FALLBACK: str = os.getenv(
+        "CHATGPT_LONG_PROMPT_FALLBACK", "attachment"
+    ).strip().lower()
+    CHATGPT_LONG_PROMPT_THRESHOLD: int = max(
+        0, int(os.getenv("CHATGPT_LONG_PROMPT_THRESHOLD", "0"))
+    )
     ATTACHMENT_EXPAND_MULTIPAGE: bool = os.getenv("ATTACHMENT_EXPAND_MULTIPAGE", "true").lower() == "true"
     ATTACHMENT_MAX_PAGES: int = int(os.getenv("ATTACHMENT_MAX_PAGES", "24"))
     ATTACHMENT_RENDER_DPI: int = int(os.getenv("ATTACHMENT_RENDER_DPI", "144"))

--- a/tests/test_long_prompt_fallback.py
+++ b/tests/test_long_prompt_fallback.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from pathlib import Path
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from src.chatgpt.client import ChatGPTClient
+from src.chatgpt.errors import PromptAttachmentFallbackError, PromptTooLongError
+from src.config import Config
+
+
+class _FakeKeyboard:
+    def __init__(self) -> None:
+        self.presses: list[str] = []
+
+    async def press(self, key: str) -> None:
+        self.presses.append(key)
+
+
+class _FakePage:
+    def __init__(self, send_state: dict | None = None) -> None:
+        self.keyboard = _FakeKeyboard()
+        self.send_state = send_state or {}
+        self.url = "https://chatgpt.com/c/test-thread"
+
+    def on(self, *_args) -> None:
+        return None
+
+    async def evaluate(self, *_args, **_kwargs):
+        return self.send_state
+
+
+class _FlowClient(ChatGPTClient):
+    def __init__(self, page: _FakePage, prompt_state: str = "prompt-too-long") -> None:
+        super().__init__(page)  # type: ignore[arg-type]
+        self.prompt_state = prompt_state
+        self.upload_calls: list[list[str]] = []
+        self.upload_error: Exception | None = None
+
+    async def _detect_page_error(self) -> str | None:
+        return None
+
+    async def _find_selector(self, *_args, **_kwargs) -> str:
+        return "#prompt-textarea"
+
+    async def _prompt_submission_state(self, _text: str) -> str:
+        return self.prompt_state
+
+    async def _upload_files(self, file_paths: list[str]) -> None:
+        self.upload_calls.append(list(file_paths))
+        if self.upload_error:
+            raise self.upload_error
+
+    async def _click_send(self) -> str:
+        return "clicked"
+
+    async def _wait_for_message_submission(self, *_args, **_kwargs) -> bool:
+        return True
+
+
+class LongPromptFallbackTests(IsolatedAsyncioTestCase):
+    async def test_prompt_state_detects_ui_error(self) -> None:
+        client = ChatGPTClient(_FakePage())  # type: ignore[arg-type]
+        client._composer_state = AsyncMock(
+            return_value={
+                "promptTooLong": True,
+                "sendButton": {"disabled": True, "ariaDisabled": "true"},
+            }
+        )
+
+        with patch("src.chatgpt.client.asyncio.sleep", new=AsyncMock()):
+            state = await client._prompt_submission_state("long prompt")
+
+        self.assertEqual(state, "prompt-too-long")
+
+    async def test_prompt_state_detects_populated_aria_disabled_composer(self) -> None:
+        client = ChatGPTClient(_FakePage())  # type: ignore[arg-type]
+        client._composer_state = AsyncMock(
+            return_value={
+                "composerText": "oversized prompt",
+                "hasStopButton": False,
+                "promptTooLong": False,
+                "sendButton": {"disabled": False, "ariaDisabled": "true"},
+            }
+        )
+
+        with patch("src.chatgpt.client.asyncio.sleep", new=AsyncMock()):
+            state = await client._prompt_submission_state("oversized prompt")
+
+        self.assertEqual(state, "prompt-too-long")
+
+    async def test_prompt_state_does_not_treat_active_generation_as_too_long(self) -> None:
+        client = ChatGPTClient(_FakePage())  # type: ignore[arg-type]
+        client._composer_state = AsyncMock(
+            return_value={
+                "composerText": "queued prompt",
+                "hasStopButton": True,
+                "promptTooLong": False,
+                "sendButton": {"disabled": False, "ariaDisabled": "true"},
+            }
+        )
+
+        with patch("src.chatgpt.client.asyncio.sleep", new=AsyncMock()):
+            state = await client._prompt_submission_state("queued prompt")
+
+        self.assertEqual(state, "disabled")
+
+    async def test_aria_disabled_without_long_prompt_is_not_enter_fallback(self) -> None:
+        client = ChatGPTClient(
+            _FakePage({"disabled": False, "ariaDisabled": "true", "visible": True})
+        )  # type: ignore[arg-type]
+        client._find_selector = AsyncMock(return_value="#composer-submit-button")
+
+        with patch("src.chatgpt.client.human_click", new=AsyncMock()) as click:
+            state = await client._click_send()
+
+        self.assertEqual(state, "disabled")
+        click.assert_not_awaited()
+        self.assertEqual(client.page.keyboard.presses, [])
+
+    async def test_native_disabled_without_long_prompt_is_not_enter_fallback(self) -> None:
+        client = ChatGPTClient(
+            _FakePage({"disabled": True, "ariaDisabled": None, "visible": True})
+        )  # type: ignore[arg-type]
+        client._find_selector = AsyncMock(return_value="#composer-submit-button")
+
+        state = await client._click_send()
+
+        self.assertEqual(state, "disabled")
+        self.assertEqual(client.page.keyboard.presses, [])
+
+    async def test_prompt_attachment_is_utf8_and_cleaned_after_success(self) -> None:
+        client = _FlowClient(_FakePage())
+        typed: list[str] = []
+
+        async def record_type(_page, _selector, text: str) -> None:
+            typed.append(text)
+
+        with (
+            patch.object(Config, "CHATGPT_LONG_PROMPT_FALLBACK", "attachment"),
+            patch("src.chatgpt.client.human_type", new=record_type),
+            patch("src.chatgpt.client.random_delay", new=AsyncMock()),
+            patch("src.chatgpt.client.count_assistant_messages", new=AsyncMock(return_value=0)),
+            patch("src.chatgpt.client.get_latest_assistant_turn_signature", new=AsyncMock(return_value=None)),
+            patch("src.chatgpt.client.get_latest_user_turn_signature", new=AsyncMock(return_value=None)),
+            patch("src.chatgpt.client.wait_for_response_complete", new=AsyncMock(return_value=True)),
+            patch("src.chatgpt.client.extract_images_from_response", new=AsyncMock(return_value=[])),
+            patch("src.chatgpt.client.extract_last_response_via_copy", new=AsyncMock(return_value="LONG_PROMPT_OK")),
+            patch("src.chatgpt.client.asyncio.sleep", new=AsyncMock()),
+        ):
+            result = await client.send_message(
+                "héllo\n" + ("x" * 5000),
+                file_paths=["existing.pdf"],
+            )
+
+        self.assertEqual(result.message, "LONG_PROMPT_OK")
+        self.assertEqual(len(client.upload_calls), 1)
+        uploaded = client.upload_calls[0]
+        self.assertEqual(uploaded[0], "existing.pdf")
+        self.assertTrue(uploaded[-1].endswith(".txt"))
+        self.assertEqual(Path(uploaded[-1]).exists(), False)
+        self.assertIn("Read the attached file", typed[1])
+
+    async def test_prompt_too_long_can_be_rejected_without_fallback(self) -> None:
+        client = _FlowClient(_FakePage())
+
+        with (
+            patch.object(Config, "CHATGPT_LONG_PROMPT_FALLBACK", "error"),
+            patch("src.chatgpt.client.human_type", new=AsyncMock()),
+            patch("src.chatgpt.client.random_delay", new=AsyncMock()),
+            patch("src.chatgpt.client.count_assistant_messages", new=AsyncMock(return_value=0)),
+            patch("src.chatgpt.client.get_latest_assistant_turn_signature", new=AsyncMock(return_value=None)),
+            patch("src.chatgpt.client.get_latest_user_turn_signature", new=AsyncMock(return_value=None)),
+        ):
+            with self.assertRaises(PromptTooLongError):
+                await client.send_message("too long")
+
+        self.assertEqual(client.upload_calls, [])
+
+    async def test_attachment_cleanup_runs_when_upload_fails(self) -> None:
+        client = _FlowClient(_FakePage())
+        client.upload_error = PromptAttachmentFallbackError("upload failed")
+
+        with (
+            patch.object(Config, "CHATGPT_LONG_PROMPT_FALLBACK", "attachment"),
+            patch("src.chatgpt.client.human_type", new=AsyncMock()),
+            patch("src.chatgpt.client.random_delay", new=AsyncMock()),
+            patch("src.chatgpt.client.count_assistant_messages", new=AsyncMock(return_value=0)),
+            patch("src.chatgpt.client.get_latest_assistant_turn_signature", new=AsyncMock(return_value=None)),
+            patch("src.chatgpt.client.get_latest_user_turn_signature", new=AsyncMock(return_value=None)),
+        ):
+            with self.assertRaises(PromptAttachmentFallbackError):
+                await client.send_message("too long")
+
+        self.assertEqual(len(client.upload_calls), 1)
+        self.assertFalse(Path(client.upload_calls[0][-1]).exists())
+
+    async def test_threshold_forces_attachment_fallback(self) -> None:
+        client = _FlowClient(_FakePage(), prompt_state="ready")
+        client._prompt_submission_state = ChatGPTClient._prompt_submission_state.__get__(client)  # type: ignore[method-assign]
+
+        with (
+            patch.object(Config, "CHATGPT_LONG_PROMPT_FALLBACK", "attachment"),
+            patch.object(Config, "CHATGPT_LONG_PROMPT_THRESHOLD", 3),
+            patch("src.chatgpt.client.human_type", new=AsyncMock()),
+            patch("src.chatgpt.client.random_delay", new=AsyncMock()),
+            patch("src.chatgpt.client.count_assistant_messages", new=AsyncMock(return_value=0)),
+            patch("src.chatgpt.client.get_latest_assistant_turn_signature", new=AsyncMock(return_value=None)),
+            patch("src.chatgpt.client.get_latest_user_turn_signature", new=AsyncMock(return_value=None)),
+            patch("src.chatgpt.client.wait_for_response_complete", new=AsyncMock(return_value=True)),
+            patch("src.chatgpt.client.extract_images_from_response", new=AsyncMock(return_value=[])),
+            patch("src.chatgpt.client.extract_last_response_via_copy", new=AsyncMock(return_value="ok")),
+            patch("src.chatgpt.client.asyncio.sleep", new=AsyncMock()),
+        ):
+            await client.send_message("abcd")
+
+        self.assertEqual(len(client.upload_calls), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_long_prompt_routes.py
+++ b/tests/test_long_prompt_routes.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from src.api import routes
+from src.api import openai_routes
+from src.api.openai_schemas import ChatCompletionRequest, ChatMessage
+from src.api.schemas import ChatRequest
+from src.chatgpt.errors import PromptAttachmentFallbackError, PromptTooLongError
+
+
+class _FailingClient:
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def send_message(self, *_args, **_kwargs):
+        raise self.error
+
+
+class LongPromptRouteTests(IsolatedAsyncioTestCase):
+    @staticmethod
+    @asynccontextmanager
+    async def _fake_page(_session):
+        yield SimpleNamespace(page=object())
+
+    async def _assert_status(self, error: Exception, status_code: int) -> None:
+        client = _FailingClient(error)
+        with (
+            patch.object(routes, "_get_client", return_value=client),
+            patch.object(routes, "acquire_browser_page", self._fake_page),
+        ):
+            with self.assertRaises(HTTPException) as context:
+                await routes.chat(ChatRequest(message="long prompt"))
+
+        self.assertEqual(context.exception.status_code, status_code)
+
+    async def test_prompt_too_long_maps_to_http_413(self) -> None:
+        await self._assert_status(PromptTooLongError("too long"), 413)
+
+    async def test_attachment_fallback_failure_maps_to_http_502(self) -> None:
+        await self._assert_status(PromptAttachmentFallbackError("upload failed"), 502)
+
+    async def test_openai_chat_executor_maps_prompt_too_long_to_http_413(self) -> None:
+        client = _FailingClient(PromptTooLongError("too long"))
+        request = ChatCompletionRequest(
+            model="catgpt-browser",
+            messages=[ChatMessage(role="user", content="long prompt")],
+        )
+        with (
+            patch.object(openai_routes, "_get_client", return_value=client),
+            patch.object(openai_routes, "_resolve_model_id", return_value="catgpt-browser"),
+            patch.object(openai_routes, "_tab_session_key", return_value=""),
+            patch.object(openai_routes, "_bind_client", return_value=client),
+            patch.object(openai_routes, "acquire_browser_page", self._fake_page),
+            patch.object(openai_routes.Config, "uses_browser", return_value=False),
+        ):
+            with self.assertRaises(HTTPException) as context:
+                await openai_routes._execute_chat_completion(request)
+
+        self.assertEqual(context.exception.status_code, 413)
+
+    async def test_async_job_preserves_prompt_error_status(self) -> None:
+        job_id = "test-long-prompt-job"
+        request = ChatCompletionRequest(
+            model="catgpt-browser",
+            messages=[ChatMessage(role="user", content="long prompt")],
+        )
+        job = openai_routes.ChatCompletionJobResponse(
+            id=job_id,
+            status="queued",
+            model=request.model,
+        )
+        async with openai_routes._jobs_lock:
+            openai_routes._jobs[job_id] = job
+
+        async def fail_execution(*_args, **_kwargs):
+            raise PromptTooLongError("too long")
+
+        try:
+            with patch.object(openai_routes, "_execute_chat_completion", fail_execution):
+                await openai_routes._run_async_chat_job(job_id, request)
+        finally:
+            async with openai_routes._jobs_lock:
+                openai_routes._jobs.pop(job_id, None)
+
+        self.assertEqual(job.status, "failed")
+        self.assertEqual(job.error_status_code, 413)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary

Introduces long-prompt attachment fallback as a new CatGPT feature. When a prompt is too large for the ChatGPT composer, CatGPT preserves the complete request in a temporary UTF-8 text file, uploads it as an attachment, and submits a short instruction asking ChatGPT to process the attached request.

## What changed

- Detects explicit prompt-length validation errors and the populated-composer state where ChatGPT disables Send without displaying an error.
- Avoids misclassifying a disabled Send button while a response is actively generating.
- Replaces oversized composer content with a concise attachment instruction.
- Preserves any files already supplied by the API caller alongside the generated prompt attachment.
- Removes temporary prompt files after both successful and failed requests.
- Refuses to use Enter as a fallback when Send is disabled, preventing accidental newlines and submission timeouts.
- Adds typed failures for rejected prompts and attachment-fallback errors.
- Maps these failures to HTTP 413 and HTTP 502 across the native and OpenAI-compatible APIs.
- Preserves the relevant status code for asynchronous OpenAI-compatible jobs.

## Configuration

- CHATGPT_LONG_PROMPT_FALLBACK=attachment enables the new behavior by default.
- CHATGPT_LONG_PROMPT_FALLBACK=error returns HTTP 413 instead of creating an attachment.
- CHATGPT_LONG_PROMPT_THRESHOLD=0 lets the ChatGPT interface determine the effective limit.
- A positive threshold can proactively route prompts through the attachment path.

## Verification

- Added focused coverage for prompt-state detection, attachment creation and cleanup, existing attachment preservation, disabled-send behavior, configuration thresholds, API status mapping, and asynchronous job errors.
- 59 focused tests pass.
- Python compilation and diff validation pass.
- End-to-end validation confirmed that an oversized prompt which disables direct submission succeeds through the attachment fallback and retains the complete original request.

Adds this capability to our fork in response to https://github.com/GautamVhavle/CatGPT-Gateway/issues/17.